### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     name: Linting
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/GingerGraham/bash-logger/security/code-scanning/2](https://github.com/GingerGraham/bash-logger/security/code-scanning/2)

In general, the fix is to explicitly configure `GITHUB_TOKEN` permissions for this workflow or for the individual `lint` job, following the principle of least privilege. Since this workflow only checks out code and runs linting via `pre-commit`, it needs at most read access to repository contents, and no write permissions or additional scopes (issues, pull-requests, etc.).

The single best fix without changing functionality is to add a minimal `permissions` block that sets `contents: read`. This can be added either at the root of the workflow (so it applies to all jobs) or under the `lint` job. To be narrowly scoped to what CodeQL highlighted (the job), we can add `permissions: contents: read` under `jobs.lint`, aligned with `runs-on`. No additional methods, imports, or definitions are needed, since this is purely a YAML configuration change in `.github/workflows/lint.yml`.

Specifically, in `.github/workflows/lint.yml`, between lines 9 and 10 (right after `runs-on: ubuntu-latest`), add:

```yaml
    permissions:
      contents: read
```

leaving the rest of the workflow unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
