### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     name: Run Test Suite
 


### PR DESCRIPTION
Potential fix for [https://github.com/GingerGraham/bash-logger/security/code-scanning/1](https://github.com/GingerGraham/bash-logger/security/code-scanning/1)

In general, to fix this issue you should explicitly declare a `permissions:` block in the workflow (either at the root so it applies to all jobs, or within each job) and restrict GITHUB_TOKEN scopes to only what the workflow needs. For a test workflow that only checks out the repo and uploads artifacts, `contents: read` is sufficient; no write permissions are required.

The best minimal fix here is to add a `permissions:` block at the job level for the `test` job. That keeps the change local to this workflow and avoids assuming anything about other jobs or workflows. Specifically, in `.github/workflows/tests.yml`, under `jobs:`, within the `test:` job and before `runs-on: ubuntu-latest`, add:

```yaml
    permissions:
      contents: read
```

No additional methods, imports, or definitions are needed, since this is purely a configuration change in the workflow file and the actions used (`actions/checkout@v6`, `actions/upload-artifact@v6`) work with these minimal permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
