### PR TITLE
fix: add bpkg support and update release preparation commands

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -53,13 +53,13 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "sed -i 's/readonly BASH_LOGGER_VERSION=\".*\"/readonly BASH_LOGGER_VERSION=\"${nextRelease.version}\"/' logging.sh && ./scripts/package-release.sh ${nextRelease.version}"
+        "prepareCmd": "sed -i 's/readonly BASH_LOGGER_VERSION=\".*\"/readonly BASH_LOGGER_VERSION=\"${nextRelease.version}\"/' logging.sh && sed -i 's/\"version\": \".*\"/\"version\": \"${nextRelease.version}\"/' bpkg.json && ./scripts/package-release.sh ${nextRelease.version}"
       }
     ],
     [
       "@semantic-release/git",
       {
-        "assets": ["CHANGELOG.md", "logging.sh"],
+        "assets": ["CHANGELOG.md", "logging.sh", "bpkg.json"],
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],

--- a/bpkg.json
+++ b/bpkg.json
@@ -1,0 +1,29 @@
+{
+  "name": "bash-logger",
+  "version": "1.2.0",
+  "description": "Production-grade logging for bash scripts with syslog compliance, journal integration, and customizable formatting",
+  "author": "Graham Watts (GingerGraham)",
+  "homepage": "https://github.com/GingerGraham/bash-logger",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GingerGraham/bash-logger.git"
+  },
+  "license": "MIT",
+  "keywords": [
+    "bash",
+    "logging",
+    "shell",
+    "syslog",
+    "systemd",
+    "journal"
+  ],
+  "scripts": [
+    "logging.sh"
+  ],
+  "files": [
+    "logging.sh",
+    "configuration/",
+    "demo-scripts/",
+    "docs/"
+  ]
+}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,6 +11,7 @@ This guide will help you get started with the Bash Logging Module quickly.
   * [Example Installation](#example-installation)
   * [Installing from a Tagged Release](#installing-from-a-tagged-release)
     * [Verifying the Download with SHA256](#verifying-the-download-with-sha256)
+  * [Install with bpkg](#install-with-bpkg)
 * [Basic Usage](#basic-usage)
 * [Your First Script](#your-first-script)
 * [Common Options](#common-options)
@@ -157,6 +158,45 @@ If you prefer to manually compare checksums:
    * **Linux/macOS:** `sha256sum logging.sh` or `shasum -a 256 logging.sh`
    * **Windows (PowerShell):** `(Get-FileHash -Path logging.sh -Algorithm SHA256).Hash`
 4. Compare the two values - they should match exactly
+
+### Install with bpkg
+
+For users of the [bpkg package manager](https://www.bpkg.sh/):
+
+```bash
+# Install the package
+bpkg install GingerGraham/bash-logger
+
+# Source in your script
+source ~/.bpkg/deps/bash-logger/logging.sh
+init_logger
+log_info "Installed via bpkg!"
+```
+
+**Update an existing installation:**
+
+```bash
+bpkg update bash-logger
+```
+
+**Global installation** (requires sudo):
+
+```bash
+sudo bpkg install -g GingerGraham/bash-logger
+# Then use: source /usr/local/bpkg/bash-logger/logging.sh
+```
+
+**Advantages:**
+
+* Package manager handles installation and updates
+* Works well for development environments
+* Easy to manage multiple shell libraries
+
+**Considerations:**
+
+* Requires bpkg to be installed first
+* User-local by default (not system-wide unless using `-g`)
+* Users need to know the bpkg installation path for sourcing
 
 ## Basic Usage
 


### PR DESCRIPTION
- added `bpkg.json` file
- updated `.releaserc.json` to update version references in `bpkg.json` as part of a release and commit back to the repo
- updated `getting-started.md` to provide guidance for using `bpkg` to install
- relates to [FEATURE] Bash Package Manager Support Fixes #13