### PR TITLE
docs(#57): clarifying log message length handling

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -78,8 +78,8 @@ init_logger [options]
 | `--stderr-level LEVEL`        | `-e`  | Messages at/above this level go to stderr        | ERROR       |
 | `--unsafe-allow-newlines`     | `-U`  | Allow newlines in log messages (unsafe)          | false       |
 | `--unsafe-allow-ansi-codes`   | `-A`  | Allow ANSI escape codes in log messages (unsafe) | false       |
-| `--max-line-length LENGTH`    |       | Max log line length for console/file output      | 4096        |
-| `--max-journal-length LENGTH` |       | Max log line length for journal output           | 4096        |
+| `--max-line-length LENGTH`    |       | Max message length before formatting             | 4096        |
+| `--max-journal-length LENGTH` |       | Max message length for journal                   | 4096        |
 
 **Default Format:**
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,10 +91,12 @@ unsafe_allow_ansi_codes = false
 # Allow ANSI color codes in log messages: true/false
 # Warning: true disables ANSI sanitization and can allow escape-sequence injection
 unsafe_allow_ansi_codes = false
-# Maximum log line length for console/file output (0 = unlimited)
+# Maximum message length before formatting for console/file output (0 = unlimited)
+# Note: Final output line may exceed this due to timestamp, level, and script name
 max_line_length = 4096
 
-# Maximum log line length for journal output (0 = unlimited)
+# Maximum message length before formatting for journal output (0 = unlimited)
+# Note: Final journal entry may exceed this due to metadata
 max_journal_length = 4096
 ```
 
@@ -116,8 +118,8 @@ max_journal_length = 4096
 | `verbose`                 | -                                           | true/false, yes/no, on/off, 1/0                                   | `false`           | Enable DEBUG level                        |
 | `unsafe_allow_newlines`   | `unsafe-allow-newlines`                     | true/false, yes/no, on/off, 1/0                                   | `false`           | Allow newlines in log messages (unsafe)   |
 | `unsafe_allow_ansi_codes` | `unsafe-allow-ansi-codes`                   | true/false, yes/no, on/off, 1/0                                   | `false`           | Allow ANSI codes in log messages (unsafe) |
-| `max_line_length`         | `max-line-length`, `log_max_line_length`    | Non-negative integer (0 = unlimited)                              | `4096`            | Max line length for console/file output   |
-| `max_journal_length`      | `max-journal-length`, `journal_max_length`  | Non-negative integer (0 = unlimited)                              | `4096`            | Max line length for journal output        |
+| `max_line_length`         | `max-line-length`, `log_max_line_length`    | Non-negative integer (0 = unlimited)                              | `4096`            | Max message length before formatting      |
+| `max_journal_length`      | `max-journal-length`, `journal_max_length`  | Non-negative integer (0 = unlimited)                              | `4096`            | Max message length for journal            |
 
 ### Boolean Values
 

--- a/docs/initialization.md
+++ b/docs/initialization.md
@@ -71,8 +71,8 @@ The `init_logger` function accepts the following options:
 | `--no-color, --no-colour`                       | Disable color output                                                                |
 | `-U, --unsafe-allow-newlines`                   | Allow newlines in log messages (not recommended; disables sanitization)             |
 | `-A, --unsafe-allow-ansi-codes`                 | Allow ANSI escape codes in log messages (not recommended; disables sanitization)    |
-| `--max-line-length LENGTH`                      | Max log line length for console/file output (0 = unlimited)                         |
-| `--max-journal-length LENGTH`                   | Max log line length for journal output (0 = unlimited)                              |
+| `--max-line-length LENGTH`                      | Max message length before formatting for console/file output (0 = unlimited)        |
+| `--max-journal-length LENGTH`                   | Max message length before formatting for journal output (0 = unlimited)             |
 
 ## Common Initialization Patterns
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,6 +33,7 @@ This guide helps you diagnose and resolve common issues with the Bash Logging Mo
 * [Format Issues](#format-issues)
   * [Format Not Applied](#format-not-applied)
   * [Newlines Replaced With Spaces](#newlines-replaced-with-spaces)
+  * [Log Lines Exceed Max Length](#log-lines-exceed-max-length)
   * [Weird Characters in Output](#weird-characters-in-output)
 * [Debugging Tips](#debugging-tips)
   * [Enable Verbose Mode](#enable-verbose-mode)
@@ -541,6 +542,42 @@ set_unsafe_allow_newlines true
 ```
 
 **Warning:** Allowing newlines can enable log injection and audit log forgery.
+
+### Log Lines Exceed Max Length
+
+**Problem:** Final log output exceeds the `--max-line-length` setting
+
+**Explanation:** The `--max-line-length` option truncates the **message portion** before
+formatting. The final output includes timestamp, level, and script name added after
+truncation, which can push the total line length beyond the specified limit.
+
+**Example:**
+
+```bash
+# With --max-line-length 50
+init_logger --max-line-length 50 --format "%d [%l] [%s] %m"
+
+log_info "This is a very long message that exceeds fifty characters"
+# Output (approx 90 chars total):
+# 2025-02-10 15:30:45 [INFO] [script.sh] This is a very lo...[truncated]
+# The message is truncated to 50 chars, but prefix adds ~40 more
+```
+
+**Solutions:**
+
+```bash
+# Option 1: Account for prefix length when setting limit
+# If format adds ~40 chars, use max_line_length of 60 for ~100 char final lines
+init_logger --max-line-length 60
+
+# Option 2: Use simpler format to reduce prefix overhead
+init_logger --format "[%l] %m" --max-line-length 100
+
+# Option 3: Disable truncation if precise line length not critical
+init_logger --max-line-length 0  # Unlimited
+```
+
+**References:** See [Configuration](configuration.md) for details on `max_line_length` setting.
 
 ### Weird Characters in Output
 

--- a/logging.sh
+++ b/logging.sh
@@ -120,8 +120,9 @@ LOG_UNSAFE_ALLOW_NEWLINES="false"
 # Set to true ONLY if you have explicit control over all logged messages and trust their source.
 LOG_UNSAFE_ALLOW_ANSI_CODES="false"
 
-# Log line length limits (defense-in-depth against excessively large messages)
-# Set to 0 to disable limits.
+# Maximum message length before formatting (defense-in-depth against excessively large messages)
+# Truncation is applied to the message portion before adding timestamp, level, and script name.
+# Final formatted output may exceed these limits. Set to 0 to disable limits.
 LOG_MAX_LINE_LENGTH=4096
 LOG_MAX_JOURNAL_LENGTH=4096
 


### PR DESCRIPTION
- added documentation and script comments to better clarify the behaviour of log message
  length handling

Fixes #57
