### PR TITLE
docs(config): ensuring config example includes ansi handling switch

### DIFF
--- a/configuration/logging.conf.example
+++ b/configuration/logging.conf.example
@@ -86,3 +86,18 @@ max_journal_length = 4096
 # When false (RECOMMENDED), newlines (\n), carriage returns (\r), and tabs (\t)
 # are replaced with spaces to prevent log injection attacks.
 # unsafe_allow_newlines = false
+
+# Allow ANSI escape codes in log messages (default: false)
+# SECURITY WARNING: When set to true, disables sanitization of ANSI escape sequences
+# in log messages. This can enable terminal manipulation attacks where malicious input
+# containing escape codes can manipulate terminal behavior or hide content.
+#
+# ONLY enable this if:
+#  1. You have explicit control over ALL logged messages (no user input)
+#  2. Your log viewing/parsing systems safely handle ANSI codes
+#  3. You understand the security implications and accept the risk
+#
+# When false (RECOMMENDED), ANSI escape sequences are stripped from incoming messages
+# to prevent terminal manipulation attacks. Note: Colors added by bash-logger itself
+# are preserved and not affected by this setting.
+# unsafe_allow_ansi_codes = false

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,9 +88,6 @@ unsafe_allow_newlines = false
 # Warning: true disables ANSI sanitization and can allow escape-sequence injection
 unsafe_allow_ansi_codes = false
 
-# Allow ANSI color codes in log messages: true/false
-# Warning: true disables ANSI sanitization and can allow escape-sequence injection
-unsafe_allow_ansi_codes = false
 # Maximum message length before formatting for console/file output (0 = unlimited)
 # Note: Final output line may exceed this due to timestamp, level, and script name
 max_line_length = 4096


### PR DESCRIPTION
- fixes [DOCS] Example config missing `unsafe_allow_ansi_codes` setting Fixes #59