### PR TITLE
fix(install): improving autorc logic

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -726,10 +726,10 @@ configure_rc_file() {
     if [ "$AUTO_RC" = true ]; then
         info "Adding source line to $rc_file"
         if {
-            echo ""
-            echo "# bash-logger"
-            echo "$source_line"
-        } >> "$rc_file" 2>/dev/null; then
+            printf '\n'
+            printf '%s\n' "# bash-logger"
+            printf '%s\n' "$source_line"
+        } >> "$rc_file"; then
             success "Added source line to $rc_file"
         else
             warn "Failed to update $rc_file. Please add the following line manually:"


### PR DESCRIPTION
- Fixes [BUG] Install - The append to "$rc_file" can fail (permissions, full disk, etc.), but the script will still print `success "
  - Fixes #71
- Fixes [BUG] Install - Inside the `AUTO_RC` branch, the `if [ ! -f "$rc_file" ]; then ... fi` check appears redundant/unreachable
  - Fixes #72