### PR TITLE
feat: adding support for syslog facility

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ See: [Configuration](docs/configuration.md)
 ### Journal Integration
 
 ```bash
-init_logger --journal --tag "myapp"
+init_logger --journal --tag "myapp" --facility "local0"
 ```
 
 See: [Journal Logging](docs/journal-logging.md)

--- a/configuration/logging.conf.example
+++ b/configuration/logging.conf.example
@@ -41,6 +41,13 @@ journal = false
 # tag = myapp
 tag =
 
+# Syslog facility for journal entries (default: daemon)
+# Valid values: kern, user, mail, daemon, auth, syslog, lpr, news, uucp,
+# cron, authpriv, ftp, local0, local1, local2, local3, local4, local5,
+# local6, local7
+# Note: local0-local7 are available for custom application use
+facility = daemon
+
 # Use UTC timestamps (default: false)
 # Set to true to use UTC time instead of local time
 utc = false

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -27,6 +27,7 @@ Complete reference for all public functions in the bash-logger module.
   * [set_timezone_utc](#set_timezone_utc)
   * [set_journal_logging](#set_journal_logging)
   * [set_journal_tag](#set_journal_tag)
+  * [set_syslog_facility](#set_syslog_facility)
   * [set_color_mode](#set_color_mode)
   * [set_unsafe_allow_newlines](#set_unsafe_allow_newlines)
   * [set_unsafe_allow_ansi_codes](#set_unsafe_allow_ansi_codes)
@@ -71,6 +72,7 @@ init_logger [options]
 | `--verbose`                   | `-v`  | Enable DEBUG level logging                       | false       |
 | `--journal`                   | `-j`  | Enable system journal logging                    | false       |
 | `--tag TAG`                   | `-t`  | Set journal tag                                  | (script)    |
+| `--facility FACILITY`         | `-F`  | Set syslog facility for journal logging          | daemon      |
 | `--utc`                       | `-u`  | Use UTC timestamps instead of local time         | false       |
 | `--format FORMAT`             | `-f`  | Set log message format                           | (see below) |
 | `--color`                     |       | Force color output                               | auto        |
@@ -865,6 +867,48 @@ set_journal_tag "myapp-${COMPONENT_NAME}"
 
 ---
 
+### set_syslog_facility
+
+Change the syslog facility used for journal log entries.
+
+**Syntax:**
+
+```bash
+set_syslog_facility FACILITY
+```
+
+**Parameters:**
+
+* `FACILITY` - One of: `kern`, `user`, `mail`, `daemon`, `auth`, `syslog`, `lpr`, `news`, `uucp`, `cron`, `authpriv`, `ftp`, `local0`, `local1`, `local2`, `local3`, `local4`, `local5`, `local6`, `local7`
+
+**Returns:**
+
+* `0` - Success
+* `1` - Invalid facility
+
+**Examples:**
+
+```bash
+# Use an application-specific facility
+set_syslog_facility local0
+
+# Switch back to default
+set_syslog_facility daemon
+```
+
+**Effects:**
+
+* Validates the facility name before applying it
+* Logs a CONFIG message documenting the change
+* Takes effect immediately for all subsequent journal log entries
+
+**See Also:**
+
+* [Runtime Configuration Guide](runtime-configuration.md#set_syslog_facility)
+* [Journal Logging Guide](journal-logging.md)
+
+---
+
 ### set_color_mode
 
 Change color output mode for console logging.
@@ -1045,6 +1089,7 @@ LOG_FILE               # Current log file path (empty if not logging to file)
 CONSOLE_LOG            # "true" or "false" - console output enabled
 USE_JOURNAL            # "true" or "false" - journal logging enabled
 JOURNAL_TAG            # Current journal tag
+SYSLOG_FACILITY        # Current syslog facility for journal entries
 USE_UTC                # "true" or "false" - UTC timestamps
 LOG_FORMAT             # Current format string
 USE_COLORS             # "auto", "always", or "never"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,6 +65,9 @@ journal = false
 # Journal/syslog tag (defaults to script name)
 tag = myapp
 
+# Syslog facility for journal entries
+facility = daemon
+
 # Use UTC timestamps: true/false
 utc = false
 
@@ -118,6 +121,13 @@ max_journal_length = 4096
 | `max_line_length`         | `max-line-length`, `log_max_line_length`    | Non-negative integer (0 = unlimited)                              | `4096`            | Max message length before formatting      |
 | `max_journal_length`      | `max-journal-length`, `journal_max_length`  | Non-negative integer (0 = unlimited)                              | `4096`            | Max message length for journal            |
 
+### Syslog Facility Key
+
+The `facility` key (alias: `syslog_facility`) controls the syslog facility used for journal entries.
+
+* Default: `daemon`
+* Valid values: `kern`, `user`, `mail`, `daemon`, `auth`, `syslog`, `lpr`, `news`, `uucp`, `cron`, `authpriv`, `ftp`, `local0`, `local1`, `local2`, `local3`, `local4`, `local5`, `local6`, `local7`
+
 ### Configuration Value Limits
 
 Configuration values are validated to ensure security and prevent issues:
@@ -125,6 +135,7 @@ Configuration values are validated to ensure security and prevent issues:
 * **All values**: Maximum length of 4,096 characters
 * **Log file paths**: Must be absolute paths (start with `/`); no control characters or shell metacharacters
 * **Journal tag**: Maximum 64 characters; shell metacharacters will be sanitized
+* **Syslog facility**: Must be one of `kern`, `user`, `mail`, `daemon`, `auth`, `syslog`, `lpr`, `news`, `uucp`, `cron`, `authpriv`, `ftp`, or `local0`-`local7`
 * **Log levels**: Must be valid level names (DEBUG-EMERGENCY) or numbers (0-7)
 * **Numeric values** (`max_line_length`, `max_journal_length`): Must be 0-1,048,576 (1MB limit)
 * **Boolean values**: Must be true/false, yes/no, on/off, or 1/0
@@ -242,6 +253,7 @@ format = %d %z [%l] [%s] %m
 log_file = /var/log/myapp/app.log
 journal = true
 tag = myapp
+facility = local0
 utc = true
 stderr_level = WARN
 quiet = false

--- a/docs/initialization.md
+++ b/docs/initialization.md
@@ -68,6 +68,7 @@ The `init_logger` function accepts the following options:
 | `-u, --utc`                                     | Use UTC time instead of local time                                                  |
 | `-j, --journal`                                 | Enable logging to systemd journal                                                   |
 | `-t, --tag TAG`                                 | Set custom tag for journal logs (default: script name)                              |
+| `-F, --facility FACILITY`                       | Set syslog facility for journal logs (default: daemon)                              |
 | `--color, --colour`                             | Explicitly enable color output (default: auto-detect)                               |
 | `--no-color, --no-colour`                       | Disable color output                                                                |
 | `-U, --unsafe-allow-newlines`                   | Allow newlines in log messages (not recommended; disables sanitization)             |
@@ -124,6 +125,9 @@ init_logger --journal
 
 # Journal with custom tag
 init_logger --journal --tag "myapp"
+
+# Journal with custom tag and facility
+init_logger --journal --tag "myapp" --facility "local0"
 
 # Journal and file logging
 init_logger --journal --log "/var/log/myapp.log" --tag "myapp"
@@ -236,6 +240,7 @@ init_logger \
   --log "/var/log/myapp/app.log" \
   --journal \
   --tag "myapp" \
+  --facility "local0" \
   --level INFO \
   --utc \
   --stderr-level WARN

--- a/docs/journal-logging.md
+++ b/docs/journal-logging.md
@@ -18,6 +18,10 @@ applications running on modern Linux distributions.
   * [Default Tag](#default-tag)
   * [Custom Tag](#custom-tag)
   * [Tag Best Practices](#tag-best-practices)
+* [Journal Facilities](#journal-facilities)
+  * [Default Facility](#default-facility)
+  * [Custom Facility](#custom-facility)
+  * [Facility Best Practices](#facility-best-practices)
 * [Log Level Mapping](#log-level-mapping)
 * [Viewing Journal Logs](#viewing-journal-logs)
   * [Basic journalctl Commands](#basic-journalctl-commands)
@@ -100,6 +104,9 @@ init_logger --journal
 # With custom tag
 init_logger --journal --tag "myapp"
 
+# With custom tag and facility
+init_logger --journal --tag "myapp" --facility "local0"
+
 # Combined with file logging
 init_logger --journal --log "/var/log/myapp.log" --tag "myapp"
 ```
@@ -110,6 +117,7 @@ init_logger --journal --log "/var/log/myapp.log" --tag "myapp"
 [logging]
 journal = true
 tag = myapp
+facility = local0
 level = INFO
 ```
 
@@ -123,6 +131,9 @@ set_journal_logging true
 
 # Change the tag
 set_journal_tag "new-app-name"
+
+# Change the facility
+set_syslog_facility local1
 
 # Disable journal logging
 set_journal_logging false
@@ -165,6 +176,44 @@ init_logger --journal --tag "database-monitor"
 2. **Keep it short** - Easier to type in journalctl commands
 3. **Use hyphens** - Better than spaces for command-line use
 4. **Be descriptive** - Make it clear what's logging
+
+## Journal Facilities
+
+Facilities determine the syslog facility class used with journal entries.
+
+### Default Facility
+
+By default, bash-logger uses:
+
+* `daemon`
+
+### Custom Facility
+
+Set a custom facility at initialization, via config file, or at runtime:
+
+```bash
+# Initialization
+init_logger --journal --facility local0
+
+# Runtime
+set_syslog_facility local1
+```
+
+```ini
+[logging]
+facility = local0
+```
+
+Valid facilities:
+
+* `kern`, `user`, `mail`, `daemon`, `auth`, `syslog`, `lpr`, `news`, `uucp`, `cron`, `authpriv`, `ftp`
+* `local0`, `local1`, `local2`, `local3`, `local4`, `local5`, `local6`, `local7`
+
+### Facility Best Practices
+
+1. **Prefer `local0`-`local7` for application logs** to avoid colliding with system-reserved classes.
+2. **Keep facility selection consistent across environments** for easier filtering and alerting.
+3. **Document the chosen facility** in service runbooks and monitoring configuration.
 
 ## Log Level Mapping
 

--- a/docs/runtime-configuration.md
+++ b/docs/runtime-configuration.md
@@ -13,7 +13,7 @@ different phases of operation.
   * [set_timezone_utc](#set_timezone_utc)
   * [set_journal_logging](#set_journal_logging)
   * [set_journal_tag](#set_journal_tag)
-    * [set_syslog_facility](#set_syslog_facility)
+  * [set_syslog_facility](#set_syslog_facility)
   * [set_unsafe_allow_newlines](#set_unsafe_allow_newlines)
   * [set_unsafe_allow_ansi_codes](#set_unsafe_allow_ansi_codes)
 * [Use Cases](#use-cases)

--- a/docs/runtime-configuration.md
+++ b/docs/runtime-configuration.md
@@ -13,6 +13,7 @@ different phases of operation.
   * [set_timezone_utc](#set_timezone_utc)
   * [set_journal_logging](#set_journal_logging)
   * [set_journal_tag](#set_journal_tag)
+    * [set_syslog_facility](#set_syslog_facility)
   * [set_unsafe_allow_newlines](#set_unsafe_allow_newlines)
   * [set_unsafe_allow_ansi_codes](#set_unsafe_allow_ansi_codes)
 * [Use Cases](#use-cases)
@@ -220,6 +221,30 @@ set_journal_tag "database-backup"
 
 # Use operation name
 set_journal_tag "cleanup-job"
+```
+
+### set_syslog_facility
+
+Change the syslog facility used for journal/syslog entries.
+
+**Syntax:**
+
+```bash
+set_syslog_facility FACILITY
+```
+
+**Parameters:**
+
+* `FACILITY` - One of: `kern`, `user`, `mail`, `daemon`, `auth`, `syslog`, `lpr`, `news`, `uucp`, `cron`, `authpriv`, `ftp`, `local0`, `local1`, `local2`, `local3`, `local4`, `local5`, `local6`, `local7`
+
+**Examples:**
+
+```bash
+# Route logs to a custom application facility
+set_syslog_facility local0
+
+# Restore default behavior
+set_syslog_facility daemon
 ```
 
 ### set_unsafe_allow_newlines

--- a/logging.sh
+++ b/logging.sh
@@ -32,6 +32,7 @@
 #     - set_timezone_utc <true|false>   : Toggle UTC timestamps
 #     - set_journal_logging <true|false>: Toggle system journal logging
 #     - set_journal_tag <tag>           : Change journal tag
+#     - set_syslog_facility <facility>  : Change syslog facility
 #     - set_color_mode <auto|always|never> : Change color output
 #     - set_unsafe_allow_newlines <true|false> : Allow newlines in log messages (NOT RECOMMENDED)
 #     - set_unsafe_allow_ansi_codes <true|false> : Allow ANSI codes in log messages (NOT RECOMMENDED)
@@ -90,6 +91,10 @@ USE_UTC="false" # Set to true to use UTC time in logs
 # Journal logging settings
 USE_JOURNAL="false"
 JOURNAL_TAG=""  # Tag for syslog/journal entries
+if ! readonly -p 2>/dev/null | grep -q "declare -[^ ]*r[^ ]* SYSLOG_FACILITY="; then
+    unset SYSLOG_FACILITY 2>/dev/null || true
+fi
+SYSLOG_FACILITY="${SYSLOG_FACILITY:-daemon}"  # Syslog facility for journal entries
 
 # Color settings
 USE_COLORS="auto"  # Can be "auto", "always", or "never"
@@ -434,6 +439,23 @@ _validate_config_journal_tag() {
     return 0
 }
 
+# Validate syslog facility value (internal)
+# Returns 0 if valid, 1 otherwise
+_validate_syslog_facility() {
+    local facility="$1"
+
+    case "$facility" in
+        kern|user|mail|daemon|auth|syslog|lpr|news|uucp|cron|authpriv|ftp|local0|local1|local2|local3|local4|local5|local6|local7)
+            return 0
+            ;;
+        *)
+            echo "Warning: Invalid syslog facility '$facility'" >&2
+            echo "  Valid facilities: kern, user, mail, daemon, auth, syslog, lpr, news, uucp, cron, authpriv, ftp, local0-local7" >&2
+            return 1
+            ;;
+    esac
+}
+
 # Parse an INI-style configuration file (internal)
 # Usage: _parse_config_file "/path/to/config.ini"
 # Returns 0 on success, 1 on error
@@ -546,6 +568,13 @@ _parse_config_file() {
                             JOURNAL_TAG="${value//[^a-zA-Z0-9._-]/_}"
                             echo "  Hint: Sanitized journal tag to remove shell metacharacters" >&2
                         fi
+                    fi
+                    ;;
+                facility|syslog_facility)
+                    if _validate_syslog_facility "$value"; then
+                        SYSLOG_FACILITY="$value"
+                    else
+                        echo "  Hint: Skipping invalid syslog facility at line $line_num" >&2
                     fi
                     ;;
                 utc|use_utc)
@@ -864,7 +893,7 @@ _write_to_journal() {
         return 1
     fi
 
-    "$LOGGER_PATH" -p "daemon.${priority}" -t "$tag" "$message" 2>/dev/null || {
+    "$LOGGER_PATH" -p "${SYSLOG_FACILITY}.${priority}" -t "$tag" "$message" 2>/dev/null || {
         if [[ -z "${LOGGER_JOURNAL_ERROR_REPORTED:-}" ]]; then
             echo "Warning: logger command failed; disabling journal logging" >&2
             LOGGER_JOURNAL_ERROR_REPORTED="yes"
@@ -1117,6 +1146,14 @@ init_logger() {
                 ;;
             -t|--tag)
                 JOURNAL_TAG="$2"
+                shift 2
+                ;;
+            -F|--facility)
+                if _validate_syslog_facility "$2"; then
+                    SYSLOG_FACILITY="$2"
+                else
+                    echo "  Hint: Keeping existing syslog facility '$SYSLOG_FACILITY'" >&2
+                fi
                 shift 2
                 ;;
             -u|--utc)
@@ -1410,6 +1447,38 @@ set_journal_tag() {
 
     # Log to journal if enabled, using the old tag
     _write_to_journal "notice" "${old_tag:-$SCRIPT_NAME}" "CONFIG: Journal tag changing to \"$JOURNAL_TAG\""
+}
+
+# Function to set syslog facility
+set_syslog_facility() {
+    local old_facility="$SYSLOG_FACILITY"
+
+    if ! _validate_syslog_facility "$1"; then
+        return 1
+    fi
+
+    SYSLOG_FACILITY="$1"
+
+    local message="Syslog facility changed from \"$old_facility\" to \"$SYSLOG_FACILITY\""
+    local log_entry
+    log_entry=$(_format_log_message "CONFIG" "$message")
+
+    # Always print to console if enabled
+    if [[ "$CONSOLE_LOG" == "true" ]]; then
+        if _should_use_colors; then
+            printf '%s\n' "${COLOR_PURPLE}${log_entry}${COLOR_RESET}"
+        else
+            printf '%s\n' "${log_entry}"
+        fi
+    fi
+
+    # Always write to log file if set
+    if [[ -n "$LOG_FILE" ]]; then
+        printf '%s\n' "${log_entry}" >> "$LOG_FILE" 2>/dev/null
+    fi
+
+    # Always log to journal if enabled
+    _write_to_journal "notice" "${JOURNAL_TAG:-$SCRIPT_NAME}" "CONFIG: $message"
 }
 
 # Function to set color mode

--- a/logging.sh
+++ b/logging.sh
@@ -444,7 +444,10 @@ _validate_config_journal_tag() {
 _validate_syslog_facility() {
     local facility="$1"
 
-    case "$facility" in
+    # Normalize facility to lowercase for case-insensitive validation
+    local facility_normalized="${facility,,}"
+
+    case "$facility_normalized" in
         kern|user|mail|daemon|auth|syslog|lpr|news|uucp|cron|authpriv|ftp|local0|local1|local2|local3|local4|local5|local6|local7)
             return 0
             ;;
@@ -572,7 +575,7 @@ _parse_config_file() {
                     ;;
                 facility|syslog_facility)
                     if _validate_syslog_facility "$value"; then
-                        SYSLOG_FACILITY="$value"
+                        SYSLOG_FACILITY="${value,,}"
                     else
                         echo "  Hint: Skipping invalid syslog facility at line $line_num" >&2
                     fi
@@ -1149,8 +1152,12 @@ init_logger() {
                 shift 2
                 ;;
             -F|--facility)
+                if [[ -z "${2:-}" ]]; then
+                    echo "Error: --facility requires a value" >&2
+                    return 1
+                fi
                 if _validate_syslog_facility "$2"; then
-                    SYSLOG_FACILITY="$2"
+                    SYSLOG_FACILITY="${2,,}"
                 else
                     echo "  Hint: Keeping existing syslog facility '$SYSLOG_FACILITY'" >&2
                 fi
@@ -1457,7 +1464,7 @@ set_syslog_facility() {
         return 1
     fi
 
-    SYSLOG_FACILITY="$1"
+    SYSLOG_FACILITY="${1,,}"
 
     local message="Syslog facility changed from \"$old_facility\" to \"$SYSLOG_FACILITY\""
     local log_entry

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # Project information
 sonar.projectKey=bash-logger
 sonar.projectName=Bash Logger
-sonar.projectVersion=2.1.2
+sonar.projectVersion=2.2.1
 
 # Source code configuration
 sonar.sources=.

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -88,6 +88,23 @@ EOF
     pass_test
 }
 
+# Test: Syslog facility in config
+test_config_syslog_facility() {
+    start_test "Syslog facility in config"
+
+    local config_file="$TEST_DIR/facility.conf"
+    cat > "$config_file" << 'EOF'
+[logging]
+facility = local5
+EOF
+
+    init_logger --config "$config_file"
+
+    assert_equals "local5" "$SYSLOG_FACILITY" || return
+
+    pass_test
+}
+
 # Test: Color settings in config
 test_config_colors() {
     start_test "Color settings in config"
@@ -483,6 +500,7 @@ test_basic_config_load
 test_multiple_config_options
 test_config_log_file
 test_config_journal
+test_config_syslog_facility
 test_config_colors
 test_config_color_variations
 test_config_stderr_level

--- a/tests/test_initialization.sh
+++ b/tests/test_initialization.sh
@@ -95,6 +95,43 @@ test_tag_option() {
     pass_test
 }
 
+# Test: Facility option
+test_facility_option() {
+    start_test "Facility option sets syslog facility"
+
+    init_logger --facility local3
+
+    assert_equals "local3" "$SYSLOG_FACILITY" || return
+
+    pass_test
+}
+
+# Test: Invalid facility option
+test_invalid_facility_option() {
+    start_test "Invalid facility option is rejected"
+
+    init_logger --facility local1
+
+    local stderr
+    stderr=$(init_logger --facility invalid_facility 2>&1 >/dev/null)
+
+    assert_contains "$stderr" "Invalid syslog facility" || return
+    assert_equals "local1" "$SYSLOG_FACILITY" || return
+
+    pass_test
+}
+
+# Test: Default syslog facility
+test_default_syslog_facility() {
+    start_test "Default syslog facility is daemon"
+
+    init_logger
+
+    assert_equals "daemon" "$SYSLOG_FACILITY" || return
+
+    pass_test
+}
+
 # Test: Format option
 test_format_option() {
     start_test "Format option sets log format"
@@ -355,6 +392,9 @@ test_level_option
 test_verbose_option
 test_utc_option
 test_tag_option
+test_facility_option
+test_invalid_facility_option
+test_default_syslog_facility
 test_format_option
 test_color_always_option
 test_color_never_option

--- a/tests/test_journal_logging.sh
+++ b/tests/test_journal_logging.sh
@@ -128,7 +128,7 @@ test_log_to_journal_uses_configured_syslog_facility() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 3: Unrecognised level name returns 1 and prints an error
+# Test 4: Unrecognised level name returns 1 and prints an error
 # ---------------------------------------------------------------------------
 test_log_to_journal_invalid_level_returns_error() {
     start_test "log_to_journal with invalid level returns 1 and prints error"
@@ -157,7 +157,7 @@ test_log_to_journal_invalid_level_returns_error() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 4: Missing arguments returns 1 and prints a usage error
+# Test 5: Missing arguments returns 1 and prints a usage error
 # ---------------------------------------------------------------------------
 test_log_to_journal_missing_args_returns_usage_error() {
     start_test "log_to_journal with missing arguments returns 1 and usage error"
@@ -197,7 +197,7 @@ test_log_to_journal_missing_args_returns_usage_error() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 5: Message below current log level is silently suppressed
+# Test 6: Message below current log level is silently suppressed
 # ---------------------------------------------------------------------------
 test_log_to_journal_below_level_is_suppressed() {
     start_test "log_to_journal message below log level is silently suppressed"
@@ -227,7 +227,7 @@ test_log_to_journal_below_level_is_suppressed() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 6: Below-level message silently suppressed even when logger unavailable
+# Test 7: Below-level message silently suppressed even when logger unavailable
 # ---------------------------------------------------------------------------
 test_log_to_journal_below_level_no_logger_no_warning() {
     start_test "log_to_journal below log level emits no warning even when logger is unavailable"
@@ -259,7 +259,7 @@ test_log_to_journal_below_level_no_logger_no_warning() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 7: logger not available — warning to stderr and return 1
+# Test 8: logger not available — warning to stderr and return 1
 # ---------------------------------------------------------------------------
 test_log_to_journal_no_logger_emits_warning() {
     start_test "log_to_journal without logger emits warning to stderr and returns 1"
@@ -291,7 +291,7 @@ test_log_to_journal_no_logger_emits_warning() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 8: Calling log_to_journal when USE_JOURNAL=true and logger is
+# Test 9: Calling log_to_journal when USE_JOURNAL=true and logger is
 # unavailable should use the existing _write_to_journal error path,
 # NOT the force_journal=true warning (no double-warn).
 # ---------------------------------------------------------------------------
@@ -331,7 +331,7 @@ test_log_to_journal_no_double_warn_when_journal_enabled() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 9: log_sensitive is unaffected — skip_journal still takes precedence
+# Test 10: log_sensitive is unaffected — skip_journal still takes precedence
 # ---------------------------------------------------------------------------
 test_log_sensitive_unaffected_by_force_journal() {
     start_test "log_sensitive still skips journal after log_to_journal change"
@@ -370,7 +370,7 @@ test_log_sensitive_unaffected_by_force_journal() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 10: Level aliases are accepted and resolve to canonical names
+# Test 11: Level aliases are accepted and resolve to canonical names
 # ---------------------------------------------------------------------------
 test_log_to_journal_level_aliases() {
     start_test "log_to_journal accepts level aliases (WARNING, ERR, CRIT, EMERG, FATAL)"
@@ -405,7 +405,7 @@ test_log_to_journal_level_aliases() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 11: Numeric syslog levels (0-7) are accepted
+# Test 12: Numeric syslog levels (0-7) are accepted
 # ---------------------------------------------------------------------------
 test_log_to_journal_numeric_levels() {
     start_test "log_to_journal accepts numeric syslog levels 0-7"

--- a/tests/test_journal_logging.sh
+++ b/tests/test_journal_logging.sh
@@ -99,6 +99,35 @@ test_log_to_journal_no_double_dispatch_when_journal_enabled() {
 }
 
 # ---------------------------------------------------------------------------
+# Test 3: Configured syslog facility is used in logger priority argument
+# ---------------------------------------------------------------------------
+test_log_to_journal_uses_configured_syslog_facility() {
+    start_test "log_to_journal uses configured syslog facility in -p"
+
+    _create_stub_logger "$TEST_DIR"
+
+    bash -c "
+        source '$PROJECT_ROOT/logging.sh'
+
+        LOGGER_PATH='$STUB_LOGGER'
+        _find_and_validate_logger() { return 0; }
+        check_logger_available() { return 0; }
+
+        init_logger --no-color --quiet --facility local3
+        USE_JOURNAL='false'
+
+        log_to_journal INFO 'facility_priority_marker'
+    " 2>/dev/null
+
+    assert_file_contains "$STUB_CAPTURE" "local3.info" \
+        "Stub logger should receive the configured facility in -p" || return
+    assert_file_contains "$STUB_CAPTURE" "facility_priority_marker" \
+        "Stub logger should capture the journal message" || return
+
+    pass_test
+}
+
+# ---------------------------------------------------------------------------
 # Test 3: Unrecognised level name returns 1 and prints an error
 # ---------------------------------------------------------------------------
 test_log_to_journal_invalid_level_returns_error() {
@@ -444,6 +473,7 @@ test_journal_option
 test_no_journal_via_runtime
 test_log_to_journal_forces_write_when_journal_disabled
 test_log_to_journal_no_double_dispatch_when_journal_enabled
+test_log_to_journal_uses_configured_syslog_facility
 test_log_to_journal_invalid_level_returns_error
 test_log_to_journal_missing_args_returns_usage_error
 test_log_to_journal_below_level_is_suppressed

--- a/tests/test_runtime_config.sh
+++ b/tests/test_runtime_config.sh
@@ -192,6 +192,50 @@ test_set_journal_tag() {
     pass_test
 }
 
+# Test: set_syslog_facility with valid value
+test_set_syslog_facility_valid() {
+    start_test "set_syslog_facility accepts valid facility"
+
+    init_logger
+
+    set_syslog_facility "local2"
+    assert_equals "local2" "$SYSLOG_FACILITY" || return
+
+    pass_test
+}
+
+# Test: set_syslog_facility with invalid value
+test_set_syslog_facility_invalid() {
+    start_test "set_syslog_facility rejects invalid facility"
+
+    init_logger
+    set_syslog_facility "local4"
+
+    if set_syslog_facility "invalid_facility" >/dev/null 2>&1; then
+        fail_test "set_syslog_facility should return non-zero for invalid facility"
+        return
+    fi
+
+    assert_equals "local4" "$SYSLOG_FACILITY" || return
+
+    pass_test
+}
+
+# Test: set_syslog_facility updates active facility
+test_set_syslog_facility_reflects_change() {
+    start_test "set_syslog_facility change is reflected"
+
+    init_logger
+
+    set_syslog_facility "local0"
+    assert_equals "local0" "$SYSLOG_FACILITY" || return
+
+    set_syslog_facility "local7"
+    assert_equals "local7" "$SYSLOG_FACILITY" || return
+
+    pass_test
+}
+
 # Test: set_color_mode function
 test_set_color_mode() {
     start_test "set_color_mode changes color setting"
@@ -558,6 +602,9 @@ test_set_timezone_utc
 test_set_timezone_local
 test_set_journal_logging
 test_set_journal_tag
+test_set_syslog_facility_valid
+test_set_syslog_facility_invalid
+test_set_syslog_facility_reflects_change
 test_set_color_mode
 test_multiple_runtime_changes
 test_runtime_changes_dont_affect_history


### PR DESCRIPTION
This pull request adds support for configuring the syslog facility used for journal logging in the bash-logger module. Users can now specify the facility (such as `local0`) via configuration files, initialization options, or at runtime. The documentation and tests have been updated to reflect this new capability.

**Syslog Facility Support**

* Added support for specifying the syslog facility for journal entries via the new `facility` (or `syslog_facility`) configuration key in config files, the `--facility`/`-F` option to `init_logger`, and the new `set_syslog_facility` runtime function. The default facility is `daemon`. Input is validated against a list of allowed syslog facilities. (`logging.sh`, `configuration/logging.conf.example`, `docs/configuration.md`, `docs/initialization.md`, `docs/journal-logging.md`, `docs/runtime-configuration.md`, `README.md`, [[1]](diffhunk://#diff-8d2cfb241a635b242f1abaee79d1582459f2423866c3ccf221e9e719096da282R94-R97) [[2]](diffhunk://#diff-8d2cfb241a635b242f1abaee79d1582459f2423866c3ccf221e9e719096da282R442-R458) [[3]](diffhunk://#diff-8d2cfb241a635b242f1abaee79d1582459f2423866c3ccf221e9e719096da282R573-R579) [[4]](diffhunk://#diff-8d2cfb241a635b242f1abaee79d1582459f2423866c3ccf221e9e719096da282L867-R896) [[5]](diffhunk://#diff-8d2cfb241a635b242f1abaee79d1582459f2423866c3ccf221e9e719096da282R1151-R1158) [[6]](diffhunk://#diff-8d2cfb241a635b242f1abaee79d1582459f2423866c3ccf221e9e719096da282R1452-R1483) [[7]](diffhunk://#diff-911b279169205678062230e3deb2bfaea35897439a37eecd2f1d5ff72ef37c0aR44-R50) [[8]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R68-R70) [[9]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R124-R138) [[10]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R256) [[11]](diffhunk://#diff-a6fc6318308d370398ab28c751b706df646c7ef33c2cba7e2599e8aa5e8c3794R71) [[12]](diffhunk://#diff-a6fc6318308d370398ab28c751b706df646c7ef33c2cba7e2599e8aa5e8c3794R129-R131) [[13]](diffhunk://#diff-a6fc6318308d370398ab28c751b706df646c7ef33c2cba7e2599e8aa5e8c3794R243) [[14]](diffhunk://#diff-1c8b262093b392994db5398ad6de489fb34a2f2b69366564ad8cf3c8dc5c1c16R21-R24) [[15]](diffhunk://#diff-1c8b262093b392994db5398ad6de489fb34a2f2b69366564ad8cf3c8dc5c1c16R107-R109) [[16]](diffhunk://#diff-1c8b262093b392994db5398ad6de489fb34a2f2b69366564ad8cf3c8dc5c1c16R120) [[17]](diffhunk://#diff-1c8b262093b392994db5398ad6de489fb34a2f2b69366564ad8cf3c8dc5c1c16R135-R137) [[18]](diffhunk://#diff-1c8b262093b392994db5398ad6de489fb34a2f2b69366564ad8cf3c8dc5c1c16R180-R217) [[19]](diffhunk://#diff-fef64b9949c243624f5d379942e1e8e5715c0a08f5d07f9121efbcfd122eb7e7R16) [[20]](diffhunk://#diff-fef64b9949c243624f5d379942e1e8e5715c0a08f5d07f9121efbcfd122eb7e7R226-R249) [[21]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L113-R113)

**Documentation Updates**

* Updated all relevant documentation to describe the new syslog facility configuration, including usage examples, valid values, best practices, and API references for both initialization and runtime changes. (`docs/configuration.md`, `docs/initialization.md`, `docs/journal-logging.md`, `docs/runtime-configuration.md`, `docs/api-reference.md`, [[1]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cR30) [[2]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cR75) [[3]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cR870-R911) [[4]](diffhunk://#diff-b1e6394ff90bfe7ea652fe504ea12eae43c8fecaa0090581cb857aa3e014ba5cR1092)

**Testing**

* Added a new test to verify that the syslog facility can be set via configuration files, and integrated it into the test suite. (`tests/test_config.sh`, [[1]](diffhunk://#diff-778eb05a0cee10f12c9dcf26970a2f390a5ff2adf91feeb061d5baf64b575e01R91-R107) [[2]](diffhunk://#diff-778eb05a0cee10f12c9dcf26970a2f390a5ff2adf91feeb061d5baf64b575e01R503)

**Version Bump**

* Bumped the project version to `2.2.1` to reflect the new feature. (`sonar-project.properties`, [sonar-project.propertiesL4-R4](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cL4-R4))