### PR TITLE
docs: add transparency about AI tool usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ Great! Here's the process:
 
 5. **Submit a PR** linking to any related issues
 
-### Maintainer Development Workflow Transparency
+### Development workflow transparency
 
 For transparency: the project maintainer uses a combination of GitHub Copilot and Claude to help develop, review, and test changes in this repository.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,12 @@ Great! Here's the process:
 
 5. **Submit a PR** linking to any related issues
 
+### Maintainer Development Workflow Transparency
+
+For transparency: the project maintainer uses a combination of GitHub Copilot and Claude to help develop, review, and test changes in this repository.
+
+Contributors are not required to use any AI tooling. Human review and maintainer approval are required before changes are merged.
+
 ### Coding Style
 
 * Use 4 spaces for indentation (no tabs)

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ See [docs/PRE-COMMIT.md](docs/PRE-COMMIT.md) for setup instructions.
 
 This project is currently maintained by [@GingerGraham](https://github.com/GingerGraham).
 
-### Development workflow transparency
+### Development Workflow Transparency
 
 The maintainer uses a combination of GitHub Copilot and Claude to assist with development, code review, and test design/execution in this repository.
 Final decisions, validation, and responsibility for merged changes remain with the maintainer.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ See [docs/PRE-COMMIT.md](docs/PRE-COMMIT.md) for setup instructions.
 
 This project is currently maintained by [@GingerGraham](https://github.com/GingerGraham).
 
+### Development workflow transparency
+
+The maintainer uses a combination of GitHub Copilot and Claude to assist with development, code review, and test design/execution in this repository.
+Final decisions, validation, and responsibility for merged changes remain with the maintainer.
+
 ## License
 
 This module is provided under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,11 @@ We provide security updates for the following versions:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 2.0.x   | :white_check_mark: |
-| 1.3.x   | :white_check_mark: |
+| 2.3.x   | :white_check_mark: |
+| 2.2.x   | :white_check_mark: |
+| 2.1.x   | :x:                |
+| 2.0.x   | :x:                |
+| 1.3.x   | :x:                |
 | 1.2.x   | :x:                |
 | 1.1.x   | :x:                |
 | 1.0.x   | :x:                |


### PR DESCRIPTION
This pull request adds transparency about the maintainer's use of AI tools in the development workflow, updates the supported versions in the security policy, and clarifies responsibility for merged changes. The most important changes are:

**Development Workflow Transparency:**

* Added a section to `CONTRIBUTING.md` explaining that the maintainer uses GitHub Copilot and Claude for development, review, and testing, but human review and approval are still required.
* Added a similar note to `README.md` clarifying the maintainer's use of AI tools and that final responsibility for merged changes remains with the maintainer.

**Security Policy Update:**

* Updated `SECURITY.md` to reflect that only versions 2.2.x and 2.3.x are currently supported for security updates; older versions are now marked as unsupported.