### PR TITLE
fix: resolved some missing quotations

### DIFF
--- a/logging.sh
+++ b/logging.sh
@@ -773,28 +773,28 @@ _get_log_level_value() {
     local line_num="${2:-}"
     case "${level_name^^}" in
         "DEBUG")
-            echo $LOG_LEVEL_DEBUG
+            echo "$LOG_LEVEL_DEBUG"
             ;;
         "INFO")
-            echo $LOG_LEVEL_INFO
+            echo "$LOG_LEVEL_INFO"
             ;;
         "NOTICE")
-            echo $LOG_LEVEL_NOTICE
+            echo "$LOG_LEVEL_NOTICE"
             ;;
         "WARN" | "WARNING")
-            echo $LOG_LEVEL_WARN
+            echo "$LOG_LEVEL_WARN"
             ;;
         "ERROR" | "ERR")
-            echo $LOG_LEVEL_ERROR
+            echo "$LOG_LEVEL_ERROR"
             ;;
         "CRITICAL" | "CRIT")
-            echo $LOG_LEVEL_CRITICAL
+            echo "$LOG_LEVEL_CRITICAL"
             ;;
         "ALERT")
-            echo $LOG_LEVEL_ALERT
+            echo "$LOG_LEVEL_ALERT"
             ;;
         "EMERGENCY" | "EMERG" | "FATAL")
-            echo $LOG_LEVEL_EMERGENCY
+            echo "$LOG_LEVEL_EMERGENCY"
             ;;
         *)
             # If it's a number between 0-7 (valid syslog levels), use it directly
@@ -807,7 +807,7 @@ _get_log_level_value() {
                     echo "  Hint: Valid levels are: DEBUG, INFO, NOTICE, WARN, ERROR, CRITICAL, ALERT, EMERGENCY (or 0-7)" >&2
                 fi
                 # Default to INFO if invalid
-                echo $LOG_LEVEL_INFO
+                echo "$LOG_LEVEL_INFO"
             fi
             ;;
     esac

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # Project information
 sonar.projectKey=bash-logger
 sonar.projectName=Bash Logger
-sonar.projectVersion=2.2.1
+sonar.projectVersion=2.5.0
 
 # Source code configuration
 sonar.sources=.


### PR DESCRIPTION
This pull request includes minor improvements to the `logging.sh` script and an update to the project version in `sonar-project.properties`. The main focus is on improving code consistency and clarity.

Shell script improvements:

* Consistently quotes all variable expansions in the `echo` statements within the `_get_log_level_value()` function in `logging.sh`, which helps prevent potential word-splitting or globbing issues. [[1]](diffhunk://#diff-8d2cfb241a635b242f1abaee79d1582459f2423866c3ccf221e9e719096da282L776-R797) [[2]](diffhunk://#diff-8d2cfb241a635b242f1abaee79d1582459f2423866c3ccf221e9e719096da282L810-R810)

Project configuration:

* Updates the `sonar.projectVersion` in `sonar-project.properties` from `2.2.1` to `2.5.0` to reflect the new version.