### PR TITLE
docs: add claude skills for linting, pre-PR checks, running tests, se…

### DIFF
--- a/.claude/skills/linting-code/SKILL.md
+++ b/.claude/skills/linting-code/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: linting-code
+description: Lints shell scripts and Markdown files in the bash-logger repository using the project's configured toolchain. Use this skill whenever checking code quality, fixing linting errors, or running lint as part of a pre-commit or pre-PR workflow.
+---
+
+# Linting Code
+
+## Tools and where configuration lives
+
+| Tool | Checks | Config |
+|---|---|---|
+| ShellCheck | Shell syntax, quoting, portability, common bugs | `.pre-commit-config.yaml` (args: `--severity=warning --external-sources`) |
+| MarkdownLint | Markdown formatting, list style, line length | `.markdownlint.yaml` |
+
+Both run through `pre-commit` so versions are pinned. Always use the Make targets or `pre-commit` directly — do not invoke `shellcheck` or `markdownlint` as standalone commands.
+
+## Commands
+
+### Lint everything (shell + Markdown)
+
+```bash
+make lint
+```
+
+### Shell scripts only
+
+```bash
+make lint-shell
+```
+
+### Markdown only
+
+```bash
+make lint-markdown
+```
+
+### Run all pre-commit hooks including tests
+
+```bash
+make pre-commit
+```
+
+### Run a single hook by name
+
+```bash
+pre-commit run shellcheck --all-files
+pre-commit run markdownlint --all-files
+```
+
+## Key rules — write clean code from the start
+
+### Shell scripts
+
+* 4-space indentation, no tabs
+* Lines ≤ 100 characters
+* Quote all variable expansions: `"$var"` not `$var`
+* `[[ ]]` for bash conditionals; `[ ]` only when POSIX portability is needed
+* `$(...)` not backticks
+* `UPPERCASE` for constants/exported vars; `lowercase` for locals and functions
+* When suppressing a ShellCheck warning, add an explanation comment:
+  ```bash
+  # shellcheck disable=SC3010 -- bash-specific syntax required for performance here
+  ```
+
+### Markdown
+
+* Unordered list markers: `*` only — **never** `-`
+* 2-space list indentation
+* Maximum line length: 200 characters (code blocks and tables are exempt)
+* Blank line above and below every heading
+* Specify a language on all fenced code blocks where possible
+
+## Interpreting failures
+
+### ShellCheck
+
+Format: `file.sh:LINE:COL: severity: message [SCXXX]`
+
+Look up unknown codes at `https://www.shellcheck.net/wiki/SCXXX`.
+
+Most common codes in this project:
+
+| Code | Cause | Fix |
+|---|---|---|
+| SC2086 | Unquoted variable | Wrap in `"$var"` |
+| SC2155 | Combined `local`/assign | Split: `local x; x=$(...)` |
+| SC2181 | Check `$?` instead of direct `if` | Use `if command; then` directly |
+
+### MarkdownLint
+
+MarkdownLint runs with `--fix` — most formatting issues auto-correct and the file is re-staged. Violations that cannot be auto-fixed (long lines, wrong list markers) require manual edits.

--- a/.claude/skills/linting-code/SKILL.md
+++ b/.claude/skills/linting-code/SKILL.md
@@ -8,7 +8,7 @@ description: Lints shell scripts and Markdown files in the bash-logger repositor
 ## Tools and where configuration lives
 
 | Tool | Checks | Config |
-|---|---|---|
+| --- | --- | --- |
 | ShellCheck | Shell syntax, quoting, portability, common bugs | `.pre-commit-config.yaml` (args: `--severity=warning --external-sources`) |
 | MarkdownLint | Markdown formatting, list style, line length | `.markdownlint.yaml` |
 
@@ -58,17 +58,22 @@ pre-commit run markdownlint --all-files
 * `$(...)` not backticks
 * `UPPERCASE` for constants/exported vars; `lowercase` for locals and functions
 * When suppressing a ShellCheck warning, add an explanation comment:
+
   ```bash
   # shellcheck disable=SC3010 -- bash-specific syntax required for performance here
   ```
 
 ### Markdown
 
-* Unordered list markers: `*` only — **never** `-`
-* 2-space list indentation
-* Maximum line length: 200 characters (code blocks and tables are exempt)
-* Blank line above and below every heading
-* Specify a language on all fenced code blocks where possible
+* Unordered list markers: `*` only — **never** `-` (MD004)
+* 2-space list indentation (MD007)
+* Maximum line length: 200 characters; code blocks and tables are exempt (MD013)
+* Blank line above and below every heading (MD022)
+* Ordered lists: use `1.` for every item, or true sequential numbers; never an arbitrary
+  starting number (MD029)
+* Table separator rows: always `| --- | --- |`, **never** `|---|---|` — MD060 compact style
+  requires a space to the left and right of every `---` cell (MD060)
+* Specify a language on all fenced code blocks where possible (optional but preferred)
 
 ## Interpreting failures
 
@@ -81,7 +86,7 @@ Look up unknown codes at `https://www.shellcheck.net/wiki/SCXXX`.
 Most common codes in this project:
 
 | Code | Cause | Fix |
-|---|---|---|
+| --- | --- | --- |
 | SC2086 | Unquoted variable | Wrap in `"$var"` |
 | SC2155 | Combined `local`/assign | Split: `local x; x=$(...)` |
 | SC2181 | Check `$?` instead of direct `if` | Use `if command; then` directly |

--- a/.claude/skills/linting-code/SKILL.md
+++ b/.claude/skills/linting-code/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: linting-code
-description: Lints shell scripts and Markdown files in the bash-logger repository using the project's configured toolchain. Use this skill whenever checking code quality, fixing linting errors, or running lint as part of a pre-commit or pre-PR workflow.
+description: >
+  Lints shell scripts and Markdown files in the bash-logger repository using the project's
+  configured toolchain. Use this skill whenever checking code quality, fixing linting errors,
+  or running lint as part of a pre-commit or pre-PR workflow.
 ---
 
 # Linting Code
@@ -93,4 +96,5 @@ Most common codes in this project:
 
 ### MarkdownLint
 
-MarkdownLint runs with `--fix` — most formatting issues auto-correct and the file is re-staged. Violations that cannot be auto-fixed (long lines, wrong list markers) require manual edits.
+MarkdownLint runs with `--fix` — most formatting issues auto-correct in-place. After auto-fix, pre-commit fails the hook and you must `git add` the modified files before re-running. Violations
+that cannot be auto-fixed (long lines, wrong list markers) require manual edits.

--- a/.claude/skills/pre-pr-checks/SKILL.md
+++ b/.claude/skills/pre-pr-checks/SKILL.md
@@ -89,7 +89,7 @@ Resolve conflicts, then re-run the full test suite.
 ## Quick-reference: common pre-PR failures
 
 | Symptom | Cause | Fix |
-|---|---|---|
+| --- | --- | --- |
 | ShellCheck SC2086 | Unquoted variable | `"$var"` |
 | ShellCheck SC2155 | Combined declare/assign | `local x; x=$(...)` |
 | MarkdownLint MD004 | List marker is `-` | Change to `*` |

--- a/.claude/skills/pre-pr-checks/SKILL.md
+++ b/.claude/skills/pre-pr-checks/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: pre-pr-checks
-description: Runs the full gate sequence before raising a pull request on bash-logger. Covers linting, targeted tests, full test suite, code review checklist, commit message audit, PR description requirements, and branch hygiene. Use this skill before pushing to a shared branch or opening a PR.
+description: >
+  Runs the full gate sequence before raising a pull request on bash-logger. Covers linting,
+  targeted tests, full test suite, code review checklist, commit message audit, PR description
+  requirements, and branch hygiene. Use this skill before pushing to a shared branch or opening
+  a PR.
 ---
 
 # Pre-PR Checks
@@ -13,7 +17,8 @@ Work through these steps in order. Each builds on the last.
 make lint
 ```
 
-Fix all ShellCheck and MarkdownLint failures. MarkdownLint auto-fixes most issues and re-stages files — review them before continuing.
+Fix all ShellCheck and MarkdownLint failures. MarkdownLint auto-fixes most issues in-place, but does not re-stage the files — run `git add` on any modified files and re-run `make lint` before
+continuing.
 
 ## 2. Targeted tests
 

--- a/.claude/skills/pre-pr-checks/SKILL.md
+++ b/.claude/skills/pre-pr-checks/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: pre-pr-checks
+description: Runs the full gate sequence before raising a pull request on bash-logger. Covers linting, targeted tests, full test suite, code review checklist, commit message audit, PR description requirements, and branch hygiene. Use this skill before pushing to a shared branch or opening a PR.
+---
+
+# Pre-PR Checks
+
+Work through these steps in order. Each builds on the last.
+
+## 1. Lint
+
+```bash
+make lint
+```
+
+Fix all ShellCheck and MarkdownLint failures. MarkdownLint auto-fixes most issues and re-stages files — review them before continuing.
+
+## 2. Targeted tests
+
+Identify relevant suites (see `running-tests` skill) and run them:
+
+```bash
+./tests/run_tests.sh <suite_name>
+```
+
+All must pass before continuing.
+
+## 3. Full test suite
+
+```bash
+./tests/run_tests.sh
+```
+
+Zero failures required. Investigate all regressions before pushing.
+
+## 4. Code review checklist
+
+### Shell scripts (`logging.sh`, `install.sh`, scripts)
+
+* [ ] Every exit path assigns the correct return/exit code — passing tests do not guarantee all exit paths are correct
+* [ ] Variables quoted throughout: `"$var"`
+* [ ] No hardcoded paths that break portability
+* [ ] New functions have comments explaining purpose and parameters
+* [ ] Shell-agnostic where possible; bash-specific constructs commented with ShellCheck suppressions
+* [ ] Lines ≤ 100 characters
+* [ ] No leftover debug `echo` or `set -x` calls
+
+### Test files
+
+* [ ] Every new test function called at the bottom of its suite file
+* [ ] `|| return` follows every assertion
+* [ ] All I/O uses `$TEST_DIR`
+
+### Documentation
+
+* [ ] New flags, functions, or behaviour documented in the relevant `.md` file
+* [ ] If `logging.sh` public API changed, `README.md` and `docs/` updated
+* [ ] Markdown uses `*` list markers, 2-space indent, ≤ 200 char lines
+
+## 5. Commit message audit
+
+```bash
+git log origin/main..HEAD --oneline
+```
+
+Every commit must follow `<type>(<scope>): <subject>` format. Amend any that do not:
+
+```bash
+git rebase -i origin/main   # reword the offending commits
+```
+
+If a commit addresses a tracked issue, confirm `Fixes #NNN` or `Refs #NNN` is in the footer. See the `writing-commits` skill for the full specification.
+
+## 6. PR description
+
+* Title: `<type>(<scope>): <subject>` matching the primary intent of the PR
+* Body must include: summary, list of changes, testing steps taken, and issue links
+* All related issues linked — at minimum the issue that prompted the work
+
+## 7. Branch hygiene
+
+```bash
+git fetch origin
+git rebase origin/main
+```
+
+Resolve conflicts, then re-run the full test suite.
+
+## Quick-reference: common pre-PR failures
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| ShellCheck SC2086 | Unquoted variable | `"$var"` |
+| ShellCheck SC2155 | Combined declare/assign | `local x; x=$(...)` |
+| MarkdownLint MD004 | List marker is `-` | Change to `*` |
+| Test not run | Call missing at bottom of suite | Add the call |
+| Assertion not reached | Missing `\|\| return` on prior assertion | Add `\|\| return` |
+| No release triggered | Commit type not release-triggering | Check `.releaserc.json` |

--- a/.claude/skills/running-tests/SKILL.md
+++ b/.claude/skills/running-tests/SKILL.md
@@ -20,7 +20,7 @@ This lists every runnable suite name. `test_example.sh` is a contributor templat
 Default to targeted. Only run the full suite for broad changes or as a pre-PR gate.
 
 | What changed | Run |
-|---|---|
+| --- | --- |
 | A specific functional area (e.g. format handling, log levels) | The matching suite(s) only |
 | `logging.sh` core logic (init, output routing, sanitization) | Full suite |
 | `install.sh` | `test_install` only |

--- a/.claude/skills/running-tests/SKILL.md
+++ b/.claude/skills/running-tests/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: running-tests
+description: Runs the bash-logger test suite — either the full suite or a targeted subset. Use this skill whenever running, selecting, or interpreting tests in this repository. Covers discovering available suites, choosing which to run after a change, correct invocation syntax, and reading test output.
+---
+
+# Running Tests
+
+## Discover available suites first
+
+Never assume which suites exist. Always discover them at runtime:
+
+```bash
+ls tests/test_*.sh | grep -v test_example.sh | grep -v test_helpers.sh | sed 's|tests/||; s|\.sh||'
+```
+
+This lists every runnable suite name. `test_example.sh` is a contributor template and `test_helpers.sh` is a shared library — neither is a runnable suite.
+
+## Choosing: targeted vs full suite
+
+Default to targeted. Only run the full suite for broad changes or as a pre-PR gate.
+
+| What changed | Run |
+|---|---|
+| A specific functional area (e.g. format handling, log levels) | The matching suite(s) only |
+| `logging.sh` core logic (init, output routing, sanitization) | Full suite |
+| `install.sh` | `test_install` only |
+| Config file parsing | `test_config` and `test_config_security` |
+| Security-related code | Relevant security suites + full suite |
+| New test file added | New suite only, then full suite |
+| Pre-PR / CI gate | Full suite |
+
+### Mapping changed code to suites
+
+After discovering available suites, match by name:
+
+* `logging.sh` format/template changes → `test_format`
+* `logging.sh` level logic → `test_log_levels`
+* `logging.sh` initialisation → `test_initialization`
+* `logging.sh` output/stream routing → `test_output`
+* Config file support → `test_config`, `test_config_security`, `test_runtime_config`
+* Journal integration → `test_journal_logging`
+* Sanitisation (ANSI, newlines, paths) → `test_ansi_injection`, `test_unsafe_newlines`, `test_path_traversal`, `test_script_name_sanitization`
+* Security hardening → `test_environment_security`, `test_sensitive_data`, `test_config_security`, `test_toctou_protection`
+* `install.sh` → `test_install`
+* JUnit/CI reporting → `test_junit_output`
+
+When in doubt about scope, run the full suite.
+
+## Commands
+
+### Full suite
+
+```bash
+./tests/run_tests.sh
+```
+
+Or via Make (quieter output):
+
+```bash
+make test
+```
+
+### Single suite
+
+```bash
+./tests/run_tests.sh <suite_name>
+```
+
+`<suite_name>` is the filename without the `test_` prefix **and** without `.sh`:
+
+```bash
+# Correct
+./tests/run_tests.sh log_levels
+./tests/run_tests.sh config
+./tests/run_tests.sh initialization
+
+# Also accepted — runner strips the extension
+./tests/run_tests.sh test_log_levels.sh
+```
+
+### Multiple suites in one invocation
+
+```bash
+./tests/run_tests.sh config config_security runtime_config
+```
+
+### JUnit XML output (for CI artefacts)
+
+```bash
+make test-junit
+```
+
+## Reading output
+
+```
+✓ (green)   — passed
+✗ (red)     — failed; expected/actual values printed below
+⊘ (yellow)  — skipped (e.g. a zsh-only test running under bash)
+```
+
+Summary line: `Total Tests: N  Passed: N  Failed: N  Skipped: N`
+
+Exit code `0` = all passed. Exit code `1` = at least one failure. Fix all failures before committing.
+
+## Mistakes to avoid
+
+* Do **not** run from inside the `tests/` directory — always run from repo root.
+* Do **not** pass the full path (`tests/test_config.sh`) — pass the suite name only.
+* Do **not** skip the discovery step and guess suite names — the list changes as the project grows.
+* `test_helpers.sh` and `test_example.sh` are never valid suite arguments.

--- a/.claude/skills/running-tests/SKILL.md
+++ b/.claude/skills/running-tests/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: running-tests
-description: Runs the bash-logger test suite — either the full suite or a targeted subset. Use this skill whenever running, selecting, or interpreting tests in this repository. Covers discovering available suites, choosing which to run after a change, correct invocation syntax, and reading test output.
+description: >
+  Runs the bash-logger test suite — either the full suite or a targeted subset. Use this skill
+  whenever running, selecting, or interpreting tests in this repository. Covers discovering
+  available suites, choosing which to run after a change, correct invocation syntax, and reading
+  test output.
 ---
 
 # Running Tests

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -1,0 +1,240 @@
+---
+name: security-review
+description: Reviews code changes in bash-logger for security issues across all protected domains. Use this skill whenever adding new features that handle external input, changing sanitization behaviour, adding config options, or reviewing a PR for security. Covers input sanitization, file system safety, config injection, environment variable attacks, journal command validation, sensitive data handling, and unsafe flag governance.
+---
+
+# Security Review
+
+## When to use this skill
+
+Apply to any change that touches:
+
+* Message processing or formatting (`_sanitize_log_message`, `_strip_ansi_codes`, format strings)
+* File path handling (`init_logger`, `_parse_config_file`, `_validate_config_file_path`)
+* Configuration parsing (new config keys, value parsing, `_parse_config_file`)
+* Journal/`logger` integration (`_find_and_validate_logger`, `_write_to_journal`)
+* Runtime setters (`set_*` functions, `--unsafe-*` flags)
+* Any new public API function that accepts external input
+
+---
+
+## Domain 1: Input sanitization (log injection)
+
+Every message written to file or journal passes through `_sanitize_log_message`, which calls
+both `_strip_ansi_codes` (strips CSI, OSC, DCS, PM, APC sequences) and newline replacement.
+
+**What to check:**
+
+* New `_log_message` callers pass user-supplied content as the `$message` argument — not
+  as part of `$level_name`, which is never sanitized (it comes from internal constants only).
+* No new code path writes directly to `$LOG_FILE` without first calling `_sanitize_log_message`.
+* If you add a new ANSI sequence type, update `_strip_ansi_codes` **and** add a test in
+  `test_ansi_injection.sh`.
+* Format string changes: `LOG_FORMAT` uses `%d`, `%l`, `%s`, `%m`, `%z` only. Never
+  interpolate raw user data into the format string itself.
+
+**Unsafe flags:**
+
+`LOG_UNSAFE_ALLOW_ANSI_CODES` and `LOG_UNSAFE_ALLOW_NEWLINES` bypass sanitization. Their
+setter functions (`set_unsafe_allow_*`, `--unsafe-allow-*` CLI flags) should:
+
+* Always emit a WARNING to console when enabling
+* Accept and validate boolean input — reject unrecognised values
+* Write the mode change to the log file and journal so the audit trail shows the unsafe window
+
+Never read `LOG_UNSAFE_*` inside `_format_log_message` or any library-generated output path
+— only the user-message path should consult them.
+
+---
+
+## Domain 2: File system security (TOCTOU, symlinks, path traversal)
+
+Log file creation in `init_logger` uses noclobber (`set -C; : > "$LOG_FILE"`) followed by
+immediate validation to minimize the TOCTOU window.
+
+**What to check:**
+
+* No existence check (`-f`, `-e`) before file creation — this re-opens the TOCTOU window.
+  Always create first, then validate.
+* After any file creation: check `-L` (reject symlinks), `-f` (must be regular file), `-w`
+  (must be writable). These three checks are mandatory in that order.
+* Path traversal: file paths from config must pass `_validate_config_file_path`, which
+  enforces absolute paths and rejects injection patterns. CLI paths are not validated by
+  `_validate_config_file_path` — if you add a new path-accepting CLI flag, apply the same
+  absolute-path and injection-pattern checks.
+* Never use `eval` or unquoted variable expansion in path construction.
+
+**Test suites for this domain:**
+
+```bash
+./tests/run_tests.sh toctou_protection
+./tests/run_tests.sh path_traversal
+```
+
+---
+
+## Domain 3: Configuration file parsing (injection, length limits)
+
+`_parse_config_file` reads untrusted INI content. All values pass through
+`_validate_config_value_length` (max `CONFIG_MAX_VALUE_LENGTH` = 4096) before any
+type-specific validation.
+
+**What to check when adding a new config key:**
+
+1. Add the key to the `case` block in `_parse_config_file`.
+2. Apply the appropriate validator:
+   * Free-form string → `_validate_string` with a sensible max length and `check_control_chars=true`
+   * File path → `_validate_config_file_path`
+   * Boolean → `_parse_bool_value`
+   * Enum (e.g. log level, facility) → existing typed validator or a new allowlist `case`
+   * Journal tag → `_validate_config_journal_tag`
+3. Never `eval` a config value. Never use `source` on config content.
+4. Verify shell metacharacters (`$`, `` ` ``, `;`, `|`, `&`, `<`, `>`) cannot reach a
+   command execution context via the new key's handling code.
+5. Add the new key name to the "Valid keys" hint in the `*` fallback branch.
+
+**Test suites for this domain:**
+
+```bash
+./tests/run_tests.sh config_security
+./tests/run_tests.sh config
+```
+
+---
+
+## Domain 4: Environment variable security
+
+On source, `logging.sh` unsets known environment variables before setting them as `readonly`
+constants (log level integers, color codes). This prevents a pre-set environment from
+poisoning constants.
+
+**What to check:**
+
+* New global constants that should not be user-overridable: unset before assignment, then
+  declare `readonly`. Follow the existing guard pattern:
+
+  ```bash
+  if ! readonly -p 2>/dev/null | grep -q "declare -[^ ]*r[^ ]* MY_CONST="; then
+      unset MY_CONST 2>/dev/null || true
+      readonly MY_CONST="value"
+  fi
+  ```
+
+* New mutable state variables (like `LOG_FILE`): these must not be `readonly`. Ensure they
+  are reset to a safe default on each `source` so pre-set environment values cannot persist.
+* `LOGGER_FILE_ERROR_REPORTED` and `LOGGER_JOURNAL_ERROR_REPORTED`: explicitly unset on
+  source so a pre-set env value cannot permanently suppress error reporting. Any new
+  "reported once" deduplication flag needs the same treatment.
+* The `IFS`, `PATH`, and other critical shell variables are not modified by the library.
+  Do not add code that sets or relies on a modified `IFS`.
+
+**Test suites for this domain:**
+
+```bash
+./tests/run_tests.sh environment_security
+```
+
+---
+
+## Domain 5: Journal / logger command validation
+
+`_find_and_validate_logger` resolves the `logger` binary via `command -v`, then resolves
+symlinks via `readlink -f`, then validates the real path against an allowlist:
+`/bin/logger`, `/usr/bin/logger`, `/usr/local/bin/logger`, `/sbin/logger`, `/usr/sbin/logger`.
+
+Once validated, `LOGGER_PATH` is set `readonly`. A changed path after lock triggers a
+warning and disables journal logging rather than accepting the new path.
+
+**What to check:**
+
+* All journal writes use `"$LOGGER_PATH"` (the validated path), never `logger` or
+  `$(command -v logger)` directly.
+* New code that invokes external commands for any purpose must apply the same
+  pattern: resolve → validate location → lock as readonly.
+* The tag passed to `_write_to_journal` is always validated by `_validate_journal_tag`
+  before use. Never pass raw user input as the tag argument.
+* Syslog facility is validated by `_validate_syslog_facility` against a strict allowlist
+  before being used in a `logger -p` invocation.
+
+---
+
+## Domain 6: Sensitive data
+
+`log_sensitive` routes messages to console only (`skip_file=true`, `skip_journal=true`).
+It bypasses the log-level filter (`force_show=true`) so sensitive output is always visible
+during interactive sessions regardless of level configuration.
+
+**What to check:**
+
+* `log_sensitive` must never write to `$LOG_FILE`. Verify `skip_file` is `"true"` and not
+  accidentally cleared by a new parameter reordering in `_log_message`.
+* `log_sensitive` must never write to the journal. Verify `skip_journal` is `"true"`.
+* No new feature should add a `--log-sensitive-to-file` option or equivalent — this
+  would defeat the purpose of the function.
+* Documentation: any new example in `docs/` or `demo-scripts/` that shows credentials,
+  tokens, or passwords must use `log_sensitive`, not `log_info` or `log_debug`.
+
+**Test suites for this domain:**
+
+```bash
+./tests/run_tests.sh sensitive_data
+```
+
+---
+
+## Domain 7: Script name sanitization
+
+`_sanitize_script_name` strips everything outside `[a-zA-Z0-9._-]`. It is applied to
+the auto-detected caller script name, any `--name` CLI argument, any `script_name` config
+value, and `SCRIPT_NAME` at the end of `init_logger` regardless of source.
+
+**What to check:**
+
+* Any new place that sets `SCRIPT_NAME` must call `_sanitize_script_name` on the value.
+* The sanitized name is used in the INIT log message and every subsequent log entry; an
+  unsanitized name would inject arbitrary content into every log line.
+
+---
+
+## Security test suite map
+
+| Area | Test suite(s) |
+|---|---|
+| ANSI injection | `test_ansi_injection` |
+| Log injection (newlines) | `test_unsafe_newlines` |
+| Path traversal | `test_path_traversal` |
+| TOCTOU / symlink attacks | `test_toctou_protection` |
+| Config file injection | `test_config_security` |
+| Environment variable attacks | `test_environment_security` |
+| Sensitive data isolation | `test_sensitive_data` |
+| Script name sanitization | `test_script_name_sanitization` |
+
+Run all security suites together:
+
+```bash
+./tests/run_tests.sh ansi_injection unsafe_newlines path_traversal toctou_protection \
+    config_security environment_security sensitive_data script_name_sanitization
+```
+
+After any security-related change, always follow with the full suite:
+
+```bash
+./tests/run_tests.sh
+```
+
+---
+
+## Security checklist before committing
+
+* [ ] New external input is sanitized before being written to file, journal, or console
+* [ ] No new code path bypasses `_sanitize_log_message`
+* [ ] No new constant is set without unset + readonly guard against env override
+* [ ] New mutable state is reset to safe default on source
+* [ ] New file path handling uses noclobber → symlink check → regular-file check → writable check
+* [ ] New config key uses an appropriate typed validator; metacharacter injection is not possible
+* [ ] Journal command is always invoked via `$LOGGER_PATH`, not `logger` directly
+* [ ] `log_sensitive` still skips file and journal (parameters not reordered)
+* [ ] Any new public setter validates its input and rejects unrecognised values
+* [ ] Unsafe flag changes still emit WARNING log entries
+* [ ] All relevant security test suites pass
+* [ ] Full test suite passes

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: security-review
-description: Reviews code changes in bash-logger for security issues across all protected domains. Use this skill whenever adding new features that handle external input, changing sanitization behaviour, adding config options, or reviewing a PR for security. Covers input sanitization, file system safety, config injection, environment variable attacks, journal command validation, sensitive data handling, and unsafe flag governance.
+description: >
+  Reviews code changes in bash-logger for security issues across all protected domains. Use this
+  skill whenever adding new features that handle external input, changing sanitization behaviour,
+  adding config options, or reviewing a PR for security. Covers input sanitization, file system
+  safety, config injection, environment variable attacks, journal command validation, sensitive
+  data handling, and unsafe flag governance.
 ---
 
 # Security Review
@@ -56,8 +61,9 @@ immediate validation to minimize the TOCTOU window.
 
 * No existence check (`-f`, `-e`) before file creation — this re-opens the TOCTOU window.
   Always create first, then validate.
-* After any file creation: check `-L` (reject symlinks), `-f` (must be regular file), `-w`
-  (must be writable). These three checks are mandatory in that order.
+* After any file creation: check `-L` (reject symlinks), `-e` (must exist — clearer error
+  than the regular-file check alone), `-f` (must be regular file), `-w` (must be writable).
+  These four checks are mandatory in that order.
 * Path traversal: file paths from config must pass `_validate_config_file_path`, which
   enforces absolute paths and rejects injection patterns. CLI paths are not validated by
   `_validate_config_file_path` — if you add a new path-accepting CLI flag, apply the same
@@ -230,7 +236,7 @@ After any security-related change, always follow with the full suite:
 * [ ] No new code path bypasses `_sanitize_log_message`
 * [ ] No new constant is set without unset + readonly guard against env override
 * [ ] New mutable state is reset to safe default on source
-* [ ] New file path handling uses noclobber → symlink check → regular-file check → writable check
+* [ ] New file path handling uses noclobber → symlink check → existence check → regular-file check → writable check
 * [ ] New config key uses an appropriate typed validator; metacharacter injection is not possible
 * [ ] Journal command is always invoked via `$LOGGER_PATH`, not `logger` directly
 * [ ] `log_sensitive` still skips file and journal (parameters not reordered)

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -199,7 +199,7 @@ value, and `SCRIPT_NAME` at the end of `init_logger` regardless of source.
 ## Security test suite map
 
 | Area | Test suite(s) |
-|---|---|
+| --- | --- |
 | ANSI injection | `test_ansi_injection` |
 | Log injection (newlines) | `test_unsafe_newlines` |
 | Path traversal | `test_path_traversal` |

--- a/.claude/skills/writing-commits/SKILL.md
+++ b/.claude/skills/writing-commits/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: writing-commits
+description: Generates correctly formatted commit messages and pull request descriptions for this repository. Uses Conventional Commits / semantic-release format with issue references. Use this skill whenever writing, reviewing, or amending a commit message or drafting a PR title and body.
+---
+
+# Writing Commits and Pull Requests
+
+## Commit message format
+
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+Commit history drives automated versioning via `semantic-release`. Incorrect format means wrong or missing version bumps and changelog entries.
+
+## Type — required
+
+| Type | Version bump | Use for |
+|---|---|---|
+| `feat` | minor | New user-visible functionality |
+| `fix` | patch | Bug fixes |
+| `perf` | patch | Performance improvements |
+| `revert` | patch | Reverting a prior commit |
+| `refactor` | patch | Internal restructuring, no behaviour change |
+| `docs` | none | Documentation-only changes |
+| `style` | none | Whitespace/formatting, no logic change |
+| `test` | none | Adding or updating tests |
+| `chore` | none | Build, tooling, dependency changes |
+| `ci` | none | GitHub Actions or CI config changes |
+
+A `BREAKING CHANGE` footer triggers a **major** bump regardless of type.
+
+## Scope — optional but strongly preferred
+
+| Scope | Use for |
+|---|---|
+| `logging` | Core `logging.sh` functions |
+| `config` | Configuration file handling |
+| `install` | `install.sh` and Makefile install targets |
+| `tests` | Test files or test infrastructure |
+| `docs` | Documentation files |
+| `scripts` | Utility or demo scripts |
+| `ci` | GitHub Actions workflows |
+| `deps` | Dependency / Dependabot changes |
+
+## Subject — required
+
+* Imperative mood: "add", "fix", "remove" — not "adds", "fixed"
+* No capital first letter
+* No trailing period
+* 50 characters or fewer
+
+## Body — optional
+
+Explain **why**, not just what. Wrap at 72 characters.
+
+## Footer — issue references
+
+Always include when the commit addresses a tracked issue:
+
+```
+Fixes #123
+Closes #456
+Refs #789
+```
+
+* `Fixes` / `Closes` — auto-closes the issue on merge
+* `Refs` — links without closing
+* Each reference on its own line
+* Multiple references are all included
+
+Breaking changes:
+
+```
+BREAKING CHANGE: <what broke and migration path>
+```
+
+## Examples
+
+```
+feat(logging): add structured JSON output format
+
+Adds --format json to init_logger. JSON output goes to the log file only;
+console output keeps the human-readable format.
+
+Closes #87
+```
+
+```
+fix(install): prevent path traversal in custom prefix validation
+
+validate_prefix now rejects paths containing '..' sequences.
+
+Fixes #102
+```
+
+```
+docs: add configuration guide for systemd and cron environments
+```
+
+```
+test(logging): add regression test for empty message handling
+
+Refs #95
+```
+
+```
+feat(logging): replace level array with associative map
+
+BREAKING CHANGE: LOG_LEVELS is now an associative array. Scripts that
+reference LOG_LEVELS by numeric index must switch to name-based keys
+(e.g. LOG_LEVELS[INFO] instead of LOG_LEVELS[1]).
+```
+
+## Pull request conventions
+
+### Title
+
+Use `<type>(<scope>): <subject>` — same format as the primary commit. If the PR contains multiple commits of the same type, use the highest-impact one.
+
+### Body structure
+
+```markdown
+## Summary
+
+One paragraph explaining what this PR does and why.
+
+## Changes
+
+* Notable change one
+* Notable change two
+
+## Testing
+
+Commands run and manual steps taken to verify.
+
+## Related issues
+
+Fixes #NNN
+Refs #NNN
+```
+
+Always include issue links in the body even when they also appear in individual commit footers.
+
+## Mistakes to avoid
+
+* Past tense ("fixed") instead of imperative ("fix")
+* Capitalised subject
+* Missing issue reference when one exists
+* Generic subjects like "update logging.sh" or "fixes"
+* Mixing unrelated changes in one commit

--- a/.claude/skills/writing-commits/SKILL.md
+++ b/.claude/skills/writing-commits/SKILL.md
@@ -20,7 +20,7 @@ Commit history drives automated versioning via `semantic-release`. Incorrect for
 ## Type — required
 
 | Type | Version bump | Use for |
-|---|---|---|
+| --- | --- | --- |
 | `feat` | minor | New user-visible functionality |
 | `fix` | patch | Bug fixes |
 | `perf` | patch | Performance improvements |
@@ -37,7 +37,7 @@ A `BREAKING CHANGE` footer triggers a **major** bump regardless of type.
 ## Scope — optional but strongly preferred
 
 | Scope | Use for |
-|---|---|
+| --- | --- |
 | `logging` | Core `logging.sh` functions |
 | `config` | Configuration file handling |
 | `install` | `install.sh` and Makefile install targets |

--- a/.claude/skills/writing-commits/SKILL.md
+++ b/.claude/skills/writing-commits/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: writing-commits
-description: Generates correctly formatted commit messages and pull request descriptions for this repository. Uses Conventional Commits / semantic-release format with issue references. Use this skill whenever writing, reviewing, or amending a commit message or drafting a PR title and body.
+description: >
+  Generates correctly formatted commit messages and pull request descriptions for this repository.
+  Uses Conventional Commits / semantic-release format with issue references. Use this skill
+  whenever writing, reviewing, or amending a commit message or drafting a PR title and body.
 ---
 
 # Writing Commits and Pull Requests

--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: writing-tests
+description: Adds new tests to the bash-logger test suite. Covers creating new test suites, adding tests to existing suites, correct use of assertions, isolation patterns, and the mandatory call registration pattern. Use this skill whenever writing, extending, or fixing tests in the tests/ directory.
+---
+
+# Writing Tests
+
+Full assertion API reference is in `docs/testing.md`. Full contributor guide is in `docs/writing-tests.md`. This skill is the step-by-step agent workflow.
+
+## Step 1 — Find the right file
+
+```bash
+ls tests/test_*.sh | grep -v test_example.sh | grep -v test_helpers.sh
+```
+
+* If a suite covering this area already exists, add to it.
+* If not, create `tests/test_<feature>.sh` by copying the template:
+
+```bash
+cp tests/test_example.sh tests/test_<feature>.sh
+chmod +x tests/test_<feature>.sh
+```
+
+Never modify `test_example.sh` — it is the contributor template.
+
+## Step 2 — Write the function
+
+```bash
+test_<feature>_<scenario>() {
+    start_test "<Human-readable description of what is being tested>"
+
+    init_logger --level DEBUG --quiet
+
+    local log_file="$TEST_DIR/test.log"
+    LOG_FILE="$log_file"
+
+    # ... test logic ...
+
+    pass_test
+}
+```
+
+Rules:
+* Function name must start with `test_` and be unique within the file
+* `start_test` **must** be the first line — it re-sources `logging.sh` and creates `$TEST_DIR`
+* `pass_test` **must** be the last line of every passing path
+* Do **not** source `logging.sh` at the top of the suite file — that runs before `$TEST_DIR` exists
+
+## Step 3 — Register the function at the bottom of the file
+
+```bash
+# At the very bottom of the suite file:
+test_<feature>_<scenario>
+```
+
+**This is mandatory.** Defining the function without calling it is a silent no-op — the runner will not discover it.
+
+## Step 4 — Use `$TEST_DIR` for all file I/O
+
+```bash
+# Correct
+local log_file="$TEST_DIR/test.log"
+
+# Wrong — causes race conditions in parallel execution
+local log_file="/tmp/test.log"
+```
+
+`$TEST_DIR` is a unique directory per test. Always use it for log files and any other file I/O.
+
+## Step 5 — Assert correctly
+
+Every assertion must be followed by `|| return`. Omitting it means a failed assertion does not stop the test and subsequent code runs against invalid state.
+
+### Most common
+
+```bash
+assert_file_contains "$log_file" "expected string" "context message" || return
+assert_file_not_contains "$log_file" "unexpected" "context message" || return
+assert_equals "expected" "$actual" "context message" || return
+assert_not_equals "unexpected" "$actual" "context message" || return
+assert_file_exists "$path" || return
+assert_file_not_exists "$path" || return
+```
+
+### Testing which stream output goes to
+
+```bash
+bash -c "
+    source '$PROJECT_ROOT/logging.sh'
+    init_logger
+    log_error 'message'
+" >"$TEST_DIR/stdout" 2>"$TEST_DIR/stderr"
+
+assert_file_contains "$TEST_DIR/stderr" "message" || return
+assert_file_not_contains "$TEST_DIR/stdout" "message" || return
+```
+
+### Exit codes
+
+```bash
+assert_command_succeeds "some_function arg" || return
+assert_command_fails "some_function bad_arg" || return
+```
+
+### Skipping conditionally
+
+```bash
+if [[ -z "${ZSH_VERSION:-}" ]]; then
+    skip_test "Not running in zsh"
+    return
+fi
+```
+
+## Step 6 — Run your suite, then the full suite
+
+```bash
+# New suite only first
+./tests/run_tests.sh <suite_name>
+
+# Then confirm no regressions
+./tests/run_tests.sh
+```
+
+## Checklist before committing
+
+* [ ] Function called at the bottom of the suite file
+* [ ] `start_test` is the first line of every test function
+* [ ] `pass_test` is the last line of every passing path
+* [ ] Every assertion uses `|| return`
+* [ ] All file I/O uses `$TEST_DIR`
+* [ ] `init_logger` called after `start_test`, not at suite top-level
+* [ ] Suite passes: `./tests/run_tests.sh <suite_name>`
+* [ ] Full suite still passes: `./tests/run_tests.sh`

--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -41,6 +41,7 @@ test_<feature>_<scenario>() {
 ```
 
 Rules:
+
 * Function name must start with `test_` and be unique within the file
 * `start_test` **must** be the first line — it re-sources `logging.sh` and creates `$TEST_DIR`
 * `pass_test` **must** be the last line of every passing path

--- a/.claude/skills/writing-tests/SKILL.md
+++ b/.claude/skills/writing-tests/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: writing-tests
-description: Adds new tests to the bash-logger test suite. Covers creating new test suites, adding tests to existing suites, correct use of assertions, isolation patterns, and the mandatory call registration pattern. Use this skill whenever writing, extending, or fixing tests in the tests/ directory.
+description: >
+  Adds new tests to the bash-logger test suite. Covers creating new test suites, adding tests to
+  existing suites, correct use of assertions, isolation patterns, and the mandatory call
+  registration pattern. Use this skill whenever writing, extending, or fixing tests in the tests/
+  directory.
 ---
 
 # Writing Tests
@@ -99,8 +103,8 @@ assert_file_not_contains "$TEST_DIR/stdout" "message" || return
 ### Exit codes
 
 ```bash
-assert_command_succeeds "some_function arg" || return
-assert_command_fails "some_function bad_arg" || return
+assert_success "some_function arg" || return
+assert_failure "some_function bad_arg" || return
 ```
 
 ### Skipping conditionally

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -227,10 +227,25 @@ When possible, write code compatible with multiple shells:
 
 ## Markdown Formatting Standards
 
-* **Unordered lists**: Always use `*` (asterisk), never `-` (dash)
-* **List indentation**: 2 spaces per level
-* **Line length**: Maximum 200 characters (configured in .markdownlint.yaml)
-* **Consistency**: Match existing documentation patterns
+All Markdown files must satisfy the rules in `.markdownlint.yaml`. The active rules are:
+
+* **MD004 — Unordered list markers**: Always use `*` (asterisk), never `-` (dash)
+* **MD007 — List indentation**: 2 spaces per level
+* **MD013 — Line length**: Maximum 200 characters; code blocks and tables are exempt
+* **MD022 — Headings**: Always one blank line above and one blank line below every heading
+* **MD029 — Ordered list style**: Use `1.` for every item (auto-increments) or true sequential
+  numbers; never start from an arbitrary number
+* **MD060 — Table separators**: Always use spaces around dashes — `| --- | --- |`, never `|---|---|`
+  (MD060 compact style requires a space to the left and right of every `---` cell)
+
+Rules explicitly disabled (allowed in this project):
+
+* Raw HTML (`MD033`): permitted
+* Duplicate headings across different sections (`MD024`): permitted (siblings-only check)
+* Emphasis used as a heading (`MD036`): permitted
+* Language tag on fenced code blocks (`MD040`): optional
+* Trailing punctuation in headings (`MD026`): permitted
+* First-line heading requirement (`MD041`): not enforced
 
 ### Guidance for Shell-Agnostic Code
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md


### PR DESCRIPTION
This pull request adds a comprehensive set of skills documentation for the `bash-logger` repository, covering linting, testing, pre-PR checks, security review, and commit conventions. These skill guides provide clear, standardized workflows and checklists to ensure code quality, security, and maintainability throughout the development lifecycle.

**Skills documentation added:**

*Linting and code quality:*
- Added `.claude/skills/linting-code/SKILL.md` detailing how to lint shell scripts and Markdown files using `pre-commit`, including tool configuration, command usage, key linting rules, and interpreting failures.

*Testing:*
- Added `.claude/skills/running-tests/SKILL.md` explaining how to discover, select, and run the test suites, map code changes to relevant tests, and interpret test output, with best practices and common mistakes to avoid.

*Pre-PR workflow:*
- Added `.claude/skills/pre-pr-checks/SKILL.md` outlining the full pre-PR gate sequence: linting, targeted and full tests, code review checklist, commit message audit, PR description requirements, and branch hygiene.

*Security review:*
- Added `.claude/skills/security-review/SKILL.md` providing a detailed security review checklist covering input sanitization, file system safety, config parsing, environment variables, journal command validation, sensitive data handling, and script name sanitization, with mappings to test suites.

*Commit and PR conventions:*
- Added `.claude/skills/writing-commits/SKILL.md` specifying the Conventional Commits format, PR title/body structure, and common mistakes, ensuring consistent commit history and changelog generation.…curity review, writing commits, and writing tests