### PR TITLE
fix: match typeset in readonly guard for zsh compatibility

### DIFF
--- a/logging.sh
+++ b/logging.sh
@@ -53,7 +53,7 @@
 # Version (updated by release workflow)
 # Guard against re-initialization when sourced multiple times
 # Use readonly status instead of emptiness to avoid environment bypass
-if ! readonly -p 2>/dev/null | grep -q "declare -[^ ]*r[^ ]* BASH_LOGGER_VERSION="; then
+if ! readonly -p 2>/dev/null | grep -qE '(declare|typeset) -[^ ]*r[^ ]* BASH_LOGGER_VERSION='; then
     readonly BASH_LOGGER_VERSION="2.5.1"
 
     # Unset potentially malicious environment variables before setting internal constants


### PR DESCRIPTION
## Problem

When sourcing bash-logger from `.zshrc`, the re-sourcing guard on line 57 fails because `readonly -p` in zsh outputs `typeset` instead of `declare`. This causes:

```
logging.sh:57: read-only variable: BASH_LOGGER_VERSION
```

## Fix

Extend the grep pattern to match both `declare` and `typeset`:

```diff
- if ! readonly -p 2>/dev/null | grep -q "declare -[^ ]*r[^ ]* BASH_LOGGER_VERSION=";
+ if ! readonly -p 2>/dev/null | grep -qE '(declare|typeset) -[^ ]*r[^ ]* BASH_LOGGER_VERSION=';
```

## Testing

Reported and confirmed by the original issue author (issue #112).

Closes #112