### PR TITLE
fix: replace bash-only ${name^^} with portable tr for zsh compatibility

### DIFF
--- a/logging.sh
+++ b/logging.sh
@@ -769,9 +769,9 @@ _parse_config_file() {
 
 # Convert log level name to numeric value (internal)
 _get_log_level_value() {
-    local level_name="$1"
+    local level_name="$(printf '%s' "$1" | tr '[:lower:]' '[:upper:]')"
     local line_num="${2:-}"
-    case "${level_name^^}" in
+    case "${level_name}" in
         "DEBUG")
             echo "$LOG_LEVEL_DEBUG"
             ;;
@@ -1898,13 +1898,13 @@ log_to_journal() {
         return 1
     fi
 
-    local level_name="$1"
+    local level_name="$(printf '%s' "$1" | tr '[:lower:]' '[:upper:]')"
     shift
     local message="$*"
 
     # Validate and normalise the level name to the canonical form used by _log_message
     local canonical_level
-    case "${level_name^^}" in
+    case "${level_name}" in
         DEBUG)                  canonical_level="DEBUG" ;;
         INFO)                   canonical_level="INFO" ;;
         NOTICE)                 canonical_level="NOTICE" ;;

--- a/logging.sh
+++ b/logging.sh
@@ -769,7 +769,8 @@ _parse_config_file() {
 
 # Convert log level name to numeric value (internal)
 _get_log_level_value() {
-    local level_name="$(printf '%s' "$1" | tr '[:lower:]' '[:upper:]')"
+    local level_name
+    level_name="$(printf '%s' "$1" | tr '[:lower:]' '[:upper:]')"
     local line_num="${2:-}"
     case "${level_name}" in
         "DEBUG")
@@ -1898,7 +1899,8 @@ log_to_journal() {
         return 1
     fi
 
-    local level_name="$(printf '%s' "$1" | tr '[:lower:]' '[:upper:]')"
+    local level_name
+    level_name="$(printf '%s' "$1" | tr '[:lower:]' '[:upper:]')"
     shift
     local message="$*"
 


### PR DESCRIPTION
## Problem

When sourcing bash-logger from `.zshrc`, the `_get_log_level_value` function produces a `bad substitution` error because `${level_name^^}` is bash 4+ specific syntax for uppercase conversion. zsh does not support this.

## Fix

Replace the bash-specific `${name^^}` case transformation with a portable equivalent using `tr`:

```diff
- local level_name="$1"
+ local level_name="$(printf '%s' "$1" | tr '[:lower:]' '[:upper:]')"
```

Also removed the now-redundant `^^` in the two case statements that used it.

Affected functions:
- `_get_log_level_value()` — converts level name to uppercase for case matching
- `log_to_journal()` — normalises level name for journald integration

## Testing

The fix was verified with `bash -n logging.sh` (syntax check passed). The `tr` command is POSIX-compliant and works in both bash and zsh.

Closes #114