### PR TITLE
docs: enhance script name handling in logging documentation

### DIFF
--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -300,6 +300,11 @@ Use `%s` when multiple scripts log to the same file:
 init_logger --log "/var/log/shared.log" --format "%d [%l] [%s] %m"
 ```
 
+The `%s` value reflects the current script name set during initialization or later via
+[set_script_name](runtime-configuration.md#set_script_name). If you want `%s` to show a
+function name or other runtime context, build that identifier in your own code and pass it
+to `set_script_name` before logging.
+
 ### 3. Include Timezone for Distributed Systems
 
 Use `%z` for systems spanning multiple timezones:

--- a/docs/initialization.md
+++ b/docs/initialization.md
@@ -202,6 +202,10 @@ init_logger --script-name "my-app"
 
 The script name appears in log messages where `%s` is used in the format string.
 
+If you need the name to change while the script is running, use
+[Runtime Configuration](runtime-configuration.md#set_script_name) and pass a caller-built
+identifier to `set_script_name`.
+
 ### Stderr Level Configuration
 
 ```bash

--- a/docs/runtime-configuration.md
+++ b/docs/runtime-configuration.md
@@ -8,9 +8,9 @@ different phases of operation.
 * [Overview](#overview)
 * [Available Functions](#available-functions)
   * [set_log_level](#set_log_level)
+  * [set_timezone_utc](#set_timezone_utc)
   * [set_log_format](#set_log_format)
   * [set_script_name](#set_script_name)
-  * [set_timezone_utc](#set_timezone_utc)
   * [set_journal_logging](#set_journal_logging)
   * [set_journal_tag](#set_journal_tag)
   * [set_syslog_facility](#set_syslog_facility)
@@ -171,6 +171,33 @@ This is particularly useful when:
 * The logger was sourced from a shell RC file (where auto-detection returns "unknown")
 * Different phases of a script should be logged with different identifiers
 * Multiple components in a script need distinct log identifiers
+
+When you want the log output to show a function name, user name, request ID, or other
+runtime context, build that identifier in your own shell code and pass the resulting string
+to `set_script_name`.
+
+```bash
+process_item() {
+    local function_name="process_item"
+    set_script_name "my-app:${function_name}"
+
+    log_info "Processing item"
+}
+
+log_as_user() {
+    local user_name=${USER:-unknown}
+    set_script_name "my-app:${user_name}"
+
+    log_info "Writing audit entry"
+}
+
+# Restore the default application name when you are done with the scoped identifier.
+set_script_name "my-app"
+```
+
+Use this pattern when the identifier needs to reflect the current caller or execution
+context. The logger does not infer function names automatically; it only displays the value
+you provide.
 
 ### set_journal_logging
 


### PR DESCRIPTION
This pull request updates the documentation to clarify how the `%s` placeholder in log formats works and provides guidance on customizing the script name for logging. It emphasizes that `%s` reflects the value set via `set_script_name`, and offers examples for dynamically setting it to reflect runtime context such as function names or user names.

Documentation improvements for `%s` and script name handling:

* Clarified in `docs/formatting.md` that `%s` in log formats reflects the script name set during initialization or via `set_script_name`, and explained how to use it for custom runtime context by updating the script name in your code.
* Updated `docs/initialization.md` to instruct users to use `set_script_name` during runtime for dynamic log identifiers, with a pointer to the runtime configuration documentation.
* Added detailed shell code examples and guidance in `docs/runtime-configuration.md` for setting `%s` to function names, user names, or other runtime-specific identifiers, and clarified that the logger does not infer these automatically.

Documentation structure and navigation:

* Fixed the order of functions in the runtime configuration documentation's table of contents to correctly list `set_timezone_utc` after `set_log_level`.
 
Fixes: #29 #30