### PR TITLE
Fix/errexit arithmetic increment

### DIFF
--- a/demo-scripts/run_demos.sh
+++ b/demo-scripts/run_demos.sh
@@ -107,7 +107,7 @@ run_all_demos() {
 
     for key in $(echo "${!DEMOS[@]}" | tr ' ' '\n' | sort); do
         if run_demo "$key"; then
-            ((success_count++))
+            success_count=$((success_count + 1))
         else
             failed_demos+=("$key")
         fi
@@ -141,7 +141,7 @@ show_menu() {
         IFS='|' read -r script title description <<< "${DEMOS[$key]}"
         printf "%2d) %-15s - %s\n" "$i" "$title" "$description"
         keys+=("$key")
-        ((i++))
+        i=$((i + 1))
     done
 
     echo

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -501,7 +501,7 @@ CURRENT=0
 log_info "Starting batch processing of $TOTAL files"
 
 for file in "${FILES[@]}"; do
-  ((CURRENT++))
+  CURRENT=$((CURRENT + 1))
   PERCENT=$((CURRENT * 100 / TOTAL))
 
   log_info "Processing [$CURRENT/$TOTAL - ${PERCENT}%]: $file"
@@ -592,9 +592,9 @@ run_test() {
 
 FAILURES=0
 
-run_test "test_database_connection" || ((FAILURES++))
-run_test "test_api_endpoint" || ((FAILURES++))
-run_test "test_data_validation" || ((FAILURES++))
+run_test "test_database_connection" || FAILURES=$((FAILURES + 1))
+run_test "test_api_endpoint" || FAILURES=$((FAILURES + 1))
+run_test "test_data_validation" || FAILURES=$((FAILURES + 1))
 
 if [[ $FAILURES -eq 0 ]]; then
   log_info "All tests passed"
@@ -717,7 +717,7 @@ process_data() {
 
   local line_count=0
   while IFS= read -r line; do
-    ((line_count++))
+    line_count=$((line_count + 1))
 
     if [[ $((line_count % 1000)) -eq 0 ]]; then
       log_info "Processed $line_count lines"

--- a/docs/runtime-configuration.md
+++ b/docs/runtime-configuration.md
@@ -786,7 +786,7 @@ ERROR_COUNT=0
 
 function process_item() {
     if ! operation; then
-        ((ERROR_COUNT++))
+        ERROR_COUNT=$((ERROR_COUNT + 1))
 
         # After 5 errors, enable debug mode
         if [[ $ERROR_COUNT -eq 5 ]]; then

--- a/logging.sh
+++ b/logging.sh
@@ -532,7 +532,7 @@ _parse_config_file() {
     local current_section=""
 
     while IFS= read -r line || [[ -n "$line" ]]; do
-        ((line_num++))
+        line_num=$((line_num + 1))
 
         # Strip UTF-8 BOM (EF BB BF) from the first line if present
         if [[ $line_num -eq 1 ]]; then
@@ -1164,7 +1164,7 @@ init_logger() {
                 break
                 ;;
         esac
-        ((i++))
+        i=$((i + 1))
     done
 
     # Second pass: parse all command line arguments (overrides config file)

--- a/scripts/create-issues.sh
+++ b/scripts/create-issues.sh
@@ -157,7 +157,7 @@ trap 'rm -f "$TMPBODY"' EXIT
 for file in "${FILES[@]}"; do
     if [[ ! -f "$file" ]]; then
         warn "File not found, skipping: $file"
-        ((SKIPPED++)) || true
+        SKIPPED=$((SKIPPED + 1))
         continue
     fi
 
@@ -169,7 +169,7 @@ for file in "${FILES[@]}"; do
 
     if [[ -z "$title" ]]; then
         warn "No 'title' found in frontmatter of $file — skipping"
-        ((SKIPPED++)) || true
+        SKIPPED=$((SKIPPED + 1))
         continue
     fi
 
@@ -197,18 +197,18 @@ for file in "${FILES[@]}"; do
         warn "  [DRY RUN] Would run: gh ${gh_args[*]}"
         warn "  [DRY RUN] Title:  $title"
         warn "  [DRY RUN] Labels: ${labels:-none}"
-        ((CREATED++)) || true
+        CREATED=$((CREATED + 1))
         continue
     fi
 
     # Create the issue
     if issue_url=$(gh "${gh_args[@]}" 2>&1); then
         ok "  Created: $issue_url"
-        ((CREATED++)) || true
+        CREATED=$((CREATED + 1))
     else
         err "  Failed to create issue for: $file"
         err "  gh output: $issue_url"
-        ((FAILED++)) || true
+        FAILED=$((FAILED + 1))
     fi
 done
 

--- a/tests/test_concurrent_access.sh
+++ b/tests/test_concurrent_access.sh
@@ -97,7 +97,7 @@ test_parallel_file_creation() {
     # Verify all files were created
     local created_count=0
     for i in {1..10}; do
-        [[ -f "$TEST_TMP_DIR/parallel_$i.log" ]] && ((created_count++))
+        [[ -f "$TEST_TMP_DIR/parallel_$i.log" ]] && created_count=$((created_count + 1))
     done
 
     if [[ $created_count -eq 10 ]]; then
@@ -176,7 +176,7 @@ test_directory_creation_race() {
     if [[ -d "$base_dir/subdir" ]]; then
         local file_count=0
         for i in {1..5}; do
-            [[ -f "$base_dir/subdir/test_$i.log" ]] && ((file_count++))
+            [[ -f "$base_dir/subdir/test_$i.log" ]] && file_count=$((file_count + 1))
         done
 
         if [[ $file_count -eq 5 ]]; then
@@ -380,7 +380,7 @@ test_concurrent_different_files() {
         if [[ -f "$TEST_TMP_DIR/different_$i.log" ]]; then
             local line_count
             line_count=$(wc -l < "$TEST_TMP_DIR/different_$i.log")
-            [[ $line_count -ge 9 ]] && ((success_count++))
+            [[ $line_count -ge 9 ]] && success_count=$((success_count + 1))
         fi
     done
 

--- a/tests/test_resource_limits.sh
+++ b/tests/test_resource_limits.sh
@@ -74,7 +74,7 @@ test_rapid_logging_rate() {
     # Log many messages quickly
     local count=0
     for i in {1..100}; do # reduced from 1000
-        log_info "Message $i" && ((count++))
+        log_info "Message $i" && count=$((count + 1))
     done
 
     # Verify most messages were logged
@@ -246,7 +246,7 @@ test_disk_space_handling() {
     local success_count=0
     for i in {1..1000}; do
         if log_info "$(printf 'Data%.0s' {1..1000})"; then
-            ((success_count++))
+            success_count=$((success_count + 1))
         else
             # If it starts failing, that's expected with disk limits
             break


### PR DESCRIPTION
## Problem Encountered

I have encountered a bug with the latest release (and main branch) where bash scripts with `set -e` can and will fail due to `init_logger()` use of `(( var++ ))`-style arithmetic method for incrementing variables.  

`logging.sh` internally (its config-file and CLI-arg parsing loops) that trips `set -e`
even though the function is designed to return 0 (see
`bash-logger/logging.sh:535,1167`). 

## Proposed Solution

Change arithmetic evaluation in this repository to arithmetic expansion and overwriting the incremented variable with this value. It's idiomatic, clean, commonly used syntax. This prevents the existing arithmetic evaluation from erroneously overwriting the functions return code.  

### Example

```bash
local i=0
while ... do;
    if [[ condition ]]; then
        i=$((i + 1))
    fi
done
```

### Other Possible Solutions

There are a handful of other arithmetic methods for incrementing these variables possible.
```bash
# Pre-increment prevents this bug
((++var))
# Other forms of Arithmetic Evaluation can cause the function to return the incorrect return code

# colon command is another option
: $((var++))

# Lastly we could assign those variables the integer property and let bash handle arithmetic on them internally
# This may have unintended consequences when the variable is re-used later on in the function.
# 
# Since this isn't a convention used elsewhere, I opted to not use this variable property.
local -i var=0
var+=1
```

## My Current Workaround

In order to work around this bug in my own repositories, I was using this adapter_call function. Which works, however it will be far simpler to fix this in `bash-logger` and use `logging.sh` directly.  

Example of my work around script (if it's helpful at all):   
```bash
# Globals:
#   None.
# Arguments:
#   $@   The bash-logger log_* function (and its arguments) to invoke.
# Outputs:
#   Whatever the invoked log_* function writes.
# Returns:
#   Always 0.
_bash_logger_adapter_call() {
  local -i errexit_was_set="0"
  [[ $- == *e* ]] && errexit_was_set="1"
  set +e

  "$@"

  (( errexit_was_set )) && set -e
  return 0
}

# Usage example
logging_adapter() {
_bash_logger_adapter_call init_logger
_bash_logger_adapter_call log_info "Message..."
}
_bash_logger_adapter_call
```